### PR TITLE
Updating pytorch to 3f974d6, includes CUDNN, NNPack, Sparse Embedding

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,7 @@ AUTOGRAD_CONTAINER_CLASS(MyModel) {
 ```
 
 Some things are not implemented:
-- CUDNN is waiting for [this massive PR](https://github.com/pytorch/pytorch/pull/3666) and more work on the PyTorch end to port it to C++
-- Lookuptables are not implemented. Even if they are sparse will be some work to get working
-- No Batchnorm but this is pretty easy.
-- Only SGD is implemented and the rest of the optimizers are just copying Python code from PyTorch over.
+- Batchnorm
+- Only SGD and Adam are implemented: the rest of the optimizers are just copying Python code from PyTorch over.
 
-Otherwise, everything else works. There may be breaking API changes as I make it easier to write models.
+Otherwise, everything else works. There may be breaking API changes.

--- a/autograd.h
+++ b/autograd.h
@@ -49,13 +49,13 @@ inline void set_grad_enabled(bool val=true) {
 }
 
 // RAII thread local lock that stops future execution from building gradients
-class no_grad {
+class no_grad_guard {
  public:
-  no_grad() {
+  no_grad_guard() {
     tag::GradMode::set_enabled(false);
   }
 
-  ~no_grad() {
+  ~no_grad_guard() {
     tag::GradMode::set_enabled(true);
   }
 };

--- a/test.cpp
+++ b/test.cpp
@@ -1,4 +1,5 @@
 #include <map>
+#include <regex>
 #include <math.h>
 #include "autograd.h"
 using namespace autograd;
@@ -10,7 +11,7 @@ using namespace autograd;
 #define EXPECT(CODE) if (CODE); else { throw std::runtime_error(__FILE__ ":" STR(__LINE__) ": " #CODE); }
 
 #if AT_CUDA_ENABLED()
-#define CUDA_GUARD ""
+#define CUDA_GUARD 
 #else
 #define CUDA_GUARD std::cerr << "No cuda, skipping test" << std::endl; return
 #endif
@@ -105,9 +106,18 @@ class CartPole {
 std::map<std::string, void (*)()> constuct_tests() {
  std::map<std::string, void (*)()> tests;
 
+ tests["autograd/no_grad/1"] = []() {
+   no_grad grad_lock;  // ag::no_grad;
+   auto model = Linear(5, 2).make();
+   auto x = Var(at::CPU(at::kFloat).randn({10, 5}), true);
+   auto y = model->forward({x})[0];
+   Variable s = y.sum();
+
+   backward(s);
+   EXPECT(!model->parameters()["weight"].grad().defined());
+ };
+
  tests["autograd/conv2d/even"] = []() {
-    at::CPU(at::kFloat).randn({2, 3, 5, 5}).size(0);
-    Var(at::CPU(at::kFloat).randn({2, 3, 5, 5}), true).size(0);
     auto model = Conv2d(3, 2, 3).stride(2).make();
     auto x = Var(at::CPU(at::kFloat).randn({2, 3, 5, 5}), true);
     auto y = model->forward({x})[0];
@@ -507,7 +517,8 @@ std::map<std::string, void (*)()> constuct_tests() {
      }
    }
 
-   auto result = std::get<1>(forward(Var(tedata, false, true)).max(1));
+   no_grad grad_lock;
+   auto result = std::get<1>(forward(Var(tedata, false)).max(1));
    Variable correct = (result == Var(telabel)).toType(at::kFloat);
    std::cout << "Num correct: " << correct.data().sum().toCFloat() 
      << " out of " << telabel.size(0) << std::endl;
@@ -617,6 +628,8 @@ int main(int argc, char** argv) {
       std::cout << "Doing " << p.first << "\n";
       p.second();
     } else {
+      auto regex = std::regex(argv[1]);
+      if (!std::regex_search(p.first, regex)) continue;
       try {
         std::cout << "Doing " << p.first << "\n";
         p.second();

--- a/test.cpp
+++ b/test.cpp
@@ -107,7 +107,7 @@ std::map<std::string, void (*)()> constuct_tests() {
  std::map<std::string, void (*)()> tests;
 
  tests["autograd/no_grad/1"] = []() {
-   no_grad grad_lock;  // ag::no_grad;
+   no_grad_guard guard;
    auto model = Linear(5, 2).make();
    auto x = Var(at::CPU(at::kFloat).randn({10, 5}), true);
    auto y = model->forward({x})[0];
@@ -517,7 +517,7 @@ std::map<std::string, void (*)()> constuct_tests() {
      }
    }
 
-   no_grad grad_lock;
+   no_grad_guard guard;
    auto result = std::get<1>(forward(Var(tedata, false)).max(1));
    Variable correct = (result == Var(telabel)).toType(at::kFloat);
    std::cout << "Num correct: " << correct.data().sum().toCFloat() 


### PR DESCRIPTION
CUDNN seems to bind now, running the mnist test:
```
Before:
real    0m41.985s
user    0m38.140s
sys     0m3.788s

After:
real    0m17.183s
user    0m15.452s
sys     0m1.656s
```

One more major change:

volatile has moved to an RAII style
```
ag::no_grad grad_lock;
```

with a forced `ag::set_enabled_grad(false)`, which is thread local.
  