### PR TITLE
Add BatchNorm container + assorted housekeeping

### DIFF
--- a/autograd.cpp
+++ b/autograd.cpp
@@ -145,7 +145,7 @@ void Conv::initialize_parameters() {
   if (!transposed_) {
     for (auto pad : output_padding_) {
       if (pad != 0) {
-        throw std::runtime_error("Only transposed convolutions support output padding!"); 
+        throw std::runtime_error("Only transposed convolutions support output padding!");
       }
     }
   }

--- a/autograd.cpp
+++ b/autograd.cpp
@@ -1,4 +1,7 @@
+#include <algorithm>
 #include <cmath>
+#include <functional>
+#include <stdexcept>
 
 #include "autograd.h"
 
@@ -205,6 +208,53 @@ variable_list Conv::forward(variable_list input) {
   }
 
   return variable_list({out});
+}
+
+void BatchNorm::initialize_parameters() {
+  if (affine_) {
+    weight = this->add(Var(DefaultTensor(at::kFloat).tensor(num_features_), true), "weight");
+    bias = this->add(Var(DefaultTensor(at::kFloat).tensor(num_features_), true), "bias");
+  }
+
+  if (stateful_) {
+    running_mean = Var(DefaultTensor(at::kFloat).zeros({num_features_}), false);
+    running_var = Var(DefaultTensor(at::kFloat).ones({num_features_}), false);
+  }
+}
+
+void BatchNorm::reset_parameters() {
+  if (affine_) {
+    weight.data().uniform_();
+    bias.data().zero_();
+  }
+
+  if (stateful_) {
+    running_mean.data().zero_();
+    running_var.data().fill_(1);
+  }
+}
+
+variable_list BatchNorm::forward(variable_list inputs) {
+  auto& input = inputs[0];
+  auto& running_mean = (stateful_ ? this->running_mean : inputs[1]);
+  auto& running_var = (stateful_ ? this->running_var : inputs[2]);
+
+  if (train_) {
+    const auto num_channels = input.dim() > 1 ? input.size(1) : 1;
+    if (input.numel() / num_channels <= 1) {
+      throw std::runtime_error(
+          "BatchNorm expected more than 1 value per channel when training!");
+    }
+  }
+
+  auto output = at::batch_norm(
+      input,
+      weight, bias,
+      running_mean, running_var,
+      train_, momentum_, eps_,
+      AT_CUDNN_ENABLED());
+
+  return variable_list({output});
 }
 
 void LSTM::initialize_parameters() {

--- a/autograd.h
+++ b/autograd.h
@@ -96,13 +96,13 @@ class no_grad_guard {
 };
 
 class ContainerImpl {
- public: 
+ public:
   virtual void reset_parameters() { };
 
   virtual variable_list forward(variable_list) = 0;
   virtual void initialize_parameters() { };
 
-  std::map<std::string, Variable> parameters() const; 
+  std::map<std::string, Variable> parameters() const;
 
   void cuda();
   void cpu();
@@ -230,7 +230,7 @@ AUTOGRAD_CONTAINER_CLASS(Embedding) {
 
 AUTOGRAD_CONTAINER_CLASS(Conv) {
  private:
-  Conv(uint32_t Nd, uint32_t in_chan, uint32_t out_chan) 
+  Conv(uint32_t Nd, uint32_t in_chan, uint32_t out_chan)
     : Nd_(Nd),
       in_channels_(in_chan),
       out_channels_(out_chan),
@@ -242,12 +242,12 @@ AUTOGRAD_CONTAINER_CLASS(Conv) {
       { }
 
  public:
-  Conv(uint32_t Nd, uint32_t in_chan, uint32_t out_chan, int ks) 
+  Conv(uint32_t Nd, uint32_t in_chan, uint32_t out_chan, int ks)
     : Conv(Nd, in_chan, out_chan) {
       ks_ = makeTup(ks, 1);
     }
 
-  Conv(uint32_t Nd, uint32_t in_chan, uint32_t out_chan, IntVec ks) 
+  Conv(uint32_t Nd, uint32_t in_chan, uint32_t out_chan, IntVec ks)
     : Conv(Nd, in_chan, out_chan) {
       ks_ = makeTup(ks);
     }
@@ -268,7 +268,7 @@ AUTOGRAD_CONTAINER_CLASS(Conv) {
   AUTOGRAD_KWARG(Conv, bool, transposed, false, true)
   AUTOGRAD_KWARG(Conv, bool, no_bias, false, true)
   AUTOGRAD_KWARG(Conv, int, groups, 1, 1)
-  
+
    Variable weight, bias;
    uint32_t Nd_;
    uint32_t in_channels_;
@@ -297,19 +297,19 @@ AUTOGRAD_CONTAINER_CLASS(Conv) {
 
 class Conv1d : public Conv {
  public:
-  Conv1d(uint32_t i, uint32_t o, int ks) : Conv(1, i, o, ks) { } 
+  Conv1d(uint32_t i, uint32_t o, int ks) : Conv(1, i, o, ks) { }
   Conv1d(uint32_t i, uint32_t o, IntVec ks) : Conv(1, i, o, ks) { }
 };
 
 class Conv2d : public Conv {
  public:
-  Conv2d(uint32_t i, uint32_t o, int ks) : Conv(2, i, o, ks) { } 
+  Conv2d(uint32_t i, uint32_t o, int ks) : Conv(2, i, o, ks) { }
   Conv2d(uint32_t i, uint32_t o, IntVec ks) : Conv(2, i, o, ks) { }
 };
 
 class Conv3d : public Conv {
  public:
-  Conv3d(uint32_t i, uint32_t o, int ks) : Conv(3, i, o, ks) { } 
+  Conv3d(uint32_t i, uint32_t o, int ks) : Conv(3, i, o, ks) { }
   Conv3d(uint32_t i, uint32_t o, IntVec ks) : Conv(3, i, o, ks) { }
 };
 
@@ -377,7 +377,7 @@ class Optimizer_CRTP : public OptimizerImpl {
     ptr->init_state();
     return ptr;
   }
- 
+
  protected:
   Optimizer_CRTP() { }
 };
@@ -393,10 +393,10 @@ AUTOGRAD_OPTIMIZER_CLASS(SGD) {
   void init_state() override;
 
   template <class Archive>
-  void serialize(Archive & ar) { 
-    ar(CEREAL_NVP(momentum_buffers_)); 
+  void serialize(Archive & ar) {
+    ar(CEREAL_NVP(momentum_buffers_));
   }
-  
+
  private:
   friend class cereal::access;
   SGD() { }
@@ -416,12 +416,12 @@ AUTOGRAD_OPTIMIZER_CLASS(Adam) {
   void init_state() override;
 
   template <class Archive>
-  void serialize(Archive & ar) { 
+  void serialize(Archive & ar) {
     ar(CEREAL_NVP(step_buffer_),
        CEREAL_NVP(exp_avg_buffer_),
-       CEREAL_NVP(exp_avg_sq_buffer_)); 
+       CEREAL_NVP(exp_avg_sq_buffer_));
   }
-  
+
  private:
   friend class cereal::access;
   Adam() { }
@@ -440,9 +440,10 @@ CEREAL_REGISTER_TYPE(autograd::Adam);
 CEREAL_REGISTER_POLYMORPHIC_RELATION(autograd::OptimizerImpl, autograd::Adam);
 
 namespace cereal {
+
 // Gradients will not be saved for variables
 template <class Archive>
-void save(Archive & archive, at::Tensor const & tensor) { 
+void save(Archive & archive, at::Tensor const & tensor) {
   if (!tensor.defined()) {
     auto type = at::ScalarType::Undefined;
     archive(CEREAL_NVP(type));
@@ -461,7 +462,7 @@ void save(Archive & archive, at::Tensor const & tensor) {
   at::Backend backend = tensor.type().backend();
 
   archive(CEREAL_NVP(backend), CEREAL_NVP(sizes), CEREAL_NVP(size));
-  archive.saveBinary(contig.storage()->data(), size); 
+  archive.saveBinary(contig.storage()->data(), size);
 }
 
 /**
@@ -483,7 +484,7 @@ void load(Archive & archive, at::Tensor & tensor) {
   auto sizes = std::vector<int64_t>();
   auto buf = std::vector<uint8_t>();
   uint64_t size;
-  archive(CEREAL_NVP(backend), CEREAL_NVP(sizes), CEREAL_NVP(size)); 
+  archive(CEREAL_NVP(backend), CEREAL_NVP(sizes), CEREAL_NVP(size));
 
   if (!tensor.defined() || tensor.type().scalarType() != type) {
     tensor = at::getType(backend, type).tensor();
@@ -498,10 +499,11 @@ void load(Archive & archive, at::Tensor & tensor) {
     tensor.resize_(sizes);
     archive.loadBinary(tensor.storage()->data(), size);
   }
-} 
+}
 
 template <class Archive>
 void load(Archive & archive, tag::Variable & var) {
   load(archive, var.data());
-} 
+}
+
 }  // namespace cereal

--- a/autograd.h
+++ b/autograd.h
@@ -313,6 +313,28 @@ class Conv3d : public Conv {
   Conv3d(uint32_t i, uint32_t o, IntVec ks) : Conv(3, i, o, ks) { }
 };
 
+AUTOGRAD_CONTAINER_CLASS(BatchNorm) {
+ public:
+  BatchNorm(uint32_t num_features)
+    : num_features_(num_features) {}
+
+  AUTOGRAD_KWARG(BatchNorm, double, eps, 1e-5, 1e-5)
+  AUTOGRAD_KWARG(BatchNorm, double, momentum, 0.1, 0.1)
+  AUTOGRAD_KWARG(BatchNorm, bool, affine, true, true)
+  AUTOGRAD_KWARG(BatchNorm, bool, stateful, false, true)
+
+  void reset_parameters() override;
+  variable_list forward(variable_list) override;
+  void initialize_parameters() override;
+
+  Variable weight;
+  Variable bias;
+  Variable running_mean;
+  Variable running_var;
+
+ protected:
+  uint32_t num_features_;
+};
 
 AUTOGRAD_CONTAINER_CLASS(Dropout) {
  public:

--- a/test.cpp
+++ b/test.cpp
@@ -11,7 +11,7 @@ using namespace autograd;
 #define EXPECT(CODE) if (CODE); else { throw std::runtime_error(__FILE__ ":" STR(__LINE__) ": " #CODE); }
 
 #if AT_CUDA_ENABLED()
-#define CUDA_GUARD 
+#define CUDA_GUARD
 #else
 #define CUDA_GUARD std::cerr << "No cuda, skipping test" << std::endl; return
 #endif
@@ -81,9 +81,9 @@ class CartPole {
       state[1] = x_dot;
       state[2] = theta;
       state[3] = theta_dot;
-      done =  x < - x_threshold 
-           || x > x_threshold 
-           || theta < -theta_threshold_radians 
+      done =  x < - x_threshold
+           || x > x_threshold
+           || theta < -theta_threshold_radians
            || theta > theta_threshold_radians
            || step_ > 200;
 
@@ -353,8 +353,8 @@ std::map<std::string, void (*)()> constuct_tests() {
      .append(Linear(2, 8).make())
      .append(Linear(8, 1).make())
      .make();
-   
-   auto optim = SGD(model, 1e-1).momentum(0.9).nesterov().weight_decay(1e-6).make(); 
+
+   auto optim = SGD(model, 1e-1).momentum(0.9).nesterov().weight_decay(1e-6).make();
 
    float running_loss = 1;
    int epoch = 0;
@@ -370,16 +370,16 @@ std::map<std::string, void (*)()> constuct_tests() {
        inp[i][1] = b;
        lab[i] = c;
      }
-     
+     //
      // forward
      auto x = Var(inp);
      auto y = Var(lab, false);
      for (auto layer : *model) x = layer->forward({x})[0].sigmoid_();
      Variable loss = at::binary_cross_entropy(x, y);
-      
+
      optim->zero_grad();
      backward(loss);
-     optim->step(); 
+     optim->step();
 
      running_loss = running_loss * 0.99 + loss.data().sum().toCFloat() * 0.01;
      EXPECT(epoch < 3000);
@@ -387,9 +387,9 @@ std::map<std::string, void (*)()> constuct_tests() {
    }
  };
 
- tests["autograd/serialization/undefined"] = []() { 
+ tests["autograd/serialization/undefined"] = []() {
    auto x = at::Tensor();
-   
+
    EXPECT(!x.defined());
 
    auto y = at::CPU(at::kFloat).randn({5});
@@ -420,7 +420,7 @@ std::map<std::string, void (*)()> constuct_tests() {
        inp[i][1] = b;
        lab[i] = c;
      }
-     
+
      // forward
      auto x = Var(inp);
      auto y = Var(lab, false);
@@ -431,7 +431,7 @@ std::map<std::string, void (*)()> constuct_tests() {
    auto model = makeModel();
    auto model2 = makeModel();
    auto model3 = makeModel();
-   auto optim = SGD(model, 1e-1).momentum(0.9).nesterov().weight_decay(1e-6).make(); 
+   auto optim = SGD(model, 1e-1).momentum(0.9).nesterov().weight_decay(1e-6).make();
 
    float running_loss = 1;
    int epoch = 0;
@@ -439,13 +439,13 @@ std::map<std::string, void (*)()> constuct_tests() {
      Variable loss = getLoss(model, 4);
      optim->zero_grad();
      backward(loss);
-     optim->step(); 
+     optim->step();
 
      running_loss = running_loss * 0.99 + loss.data().sum().toCFloat() * 0.01;
      EXPECT(epoch < 3000);
      epoch++;
    }
-   
+
    std::stringstream ss;
    save(ss, model);
    load(ss, model2);
@@ -476,11 +476,11 @@ std::map<std::string, void (*)()> constuct_tests() {
    load(ss, model3);
 
    // Make some optimizers with momentum (and thus state)
-   auto optim1 = SGD(model1, 1e-1).momentum(0.9).make(); 
-   auto optim2 = SGD(model2, 1e-1).momentum(0.9).make(); 
-   auto optim2_2 = SGD(model2, 1e-1).momentum(0.9).make(); 
-   auto optim3 = SGD(model3, 1e-1).momentum(0.9).make(); 
-   auto optim3_2 = SGD(model3, 1e-1).momentum(0.9).make(); 
+   auto optim1 = SGD(model1, 1e-1).momentum(0.9).make();
+   auto optim2 = SGD(model2, 1e-1).momentum(0.9).make();
+   auto optim2_2 = SGD(model2, 1e-1).momentum(0.9).make();
+   auto optim3 = SGD(model3, 1e-1).momentum(0.9).make();
+   auto optim3_2 = SGD(model3, 1e-1).momentum(0.9).make();
 
    auto x = Var(at::CPU(at::kFloat).ones({10, 5}), true);
 
@@ -498,7 +498,7 @@ std::map<std::string, void (*)()> constuct_tests() {
    // Do 2 steps of model 2 without saving the optimizer
    step(optim2, model2);
    step(optim2_2, model2);
-   
+
    // Do 2 steps of model 3 while saving the optimizer
    step(optim3, model3);
    ss.clear();
@@ -560,7 +560,7 @@ std::map<std::string, void (*)()> constuct_tests() {
        for (int i = 0; i < image_rows; i++)
          for (int j = 0; j < image_cols; j++) {
            a_data[c][0][i][j] = float(rd.read_byte()) / 255;
-     }     
+     }
 
      return data.toBackend(useGPU ? at::kCUDA : at::kCPU);
    };
@@ -592,8 +592,8 @@ std::map<std::string, void (*)()> constuct_tests() {
    auto linear1 = model->add(Linear(320, 50).make(), "linear1");
    auto linear2 = model->add(Linear(50, 10).make(), "linear2");
    if (useGPU) model->cuda();
-   
-   auto optim = SGD(model, 1e-2).momentum(0.5).make(); 
+
+   auto optim = SGD(model, 1e-2).momentum(0.5).make();
 
    auto forward = [&](Variable x) {
      x = std::get<0>(at::max_pool2d(conv1->forward({x})[0], {2, 2})).clamp_min(0);
@@ -630,14 +630,14 @@ std::map<std::string, void (*)()> constuct_tests() {
 
        optim->zero_grad();
        backward(loss);
-       optim->step(); 
+       optim->step();
      }
    }
 
    no_grad_guard guard;
    auto result = std::get<1>(forward(Var(tedata, false)).max(1));
    Variable correct = (result == Var(telabel)).toType(at::kFloat);
-   std::cout << "Num correct: " << correct.data().sum().toCFloat() 
+   std::cout << "Num correct: " << correct.data().sum().toCFloat()
      << " out of " << telabel.size(0) << std::endl;
    EXPECT(correct.data().sum().toCFloat() > telabel.size(0) * 0.8);
    return;
@@ -669,7 +669,7 @@ std::map<std::string, void (*)()> constuct_tests() {
      auto probs = Variable(std::get<0>(out));
      auto value = Variable(std::get<1>(out));
      auto action = probs.data().multinomial(1)[0].toCInt();
-     // Compute the log prob of a multinomial distribution. 
+     // Compute the log prob of a multinomial distribution.
      // This should probably be actually implemented in autogradpp...
      auto p = probs / probs.sum(-1, true);
      auto log_prob = p[action].log();


### PR DESCRIPTION
Integration tests show that adding batchnorm to the first linear layer improves accuracy ~2%, all else equal. This holds across affine and non-affine so is probably not just a result of the extra gamma/beta parameters.

One thing I'd like to know (I'll revise the PR as needed): how can I query the ``cudnn_enabled`` state? I assume using ``cuda_`` and hoping that ``cuda_`` implies ``cudnn_enabled`` is bad, but I was unable to find any cudnn related stuff here.