### PR TITLE
Fixing build for clang

### DIFF
--- a/autograd.h
+++ b/autograd.h
@@ -428,7 +428,6 @@ AUTOGRAD_OPTIMIZER_CLASS(SGD) {
 
 AUTOGRAD_OPTIMIZER_CLASS(Adam) {
  public:
-  using OptimizerImpl::OptimizerImpl;
   Adam(Container model, double lr) : Optimizer_CRTP(model), lr_(lr) { }
   AUTOGRAD_KWARG(Adam, double, beta1, 0.9, 0.9);
   AUTOGRAD_KWARG(Adam, double, beta2, 0.999, 0.999);


### PR DESCRIPTION
Not sure if it works on other compilers, but I'm getting
"autograd.h:431:3: error: 'autograd::OptimizerImpl' is not a direct base of 'Adam', cannot inherit constructors with this line. " when this line is present.