### PR TITLE
Provide tensor serialization methods for all archive formats

### DIFF
--- a/autograd.h
+++ b/autograd.h
@@ -462,6 +462,37 @@ CEREAL_REGISTER_POLYMORPHIC_RELATION(autograd::OptimizerImpl, autograd::Adam);
 
 namespace cereal {
 
+namespace agimpl {
+
+template <class Archive>
+void saveBinary(Archive & archive, void const * data, std::size_t size) {
+  // In general, there's no direct `saveBinary`-like method on archives
+  std::vector<char> v(reinterpret_cast<char const*>(data),
+      reinterpret_cast<char const*>(data) + size);
+  archive(v);
+}
+template <>
+inline void saveBinary(BinaryOutputArchive & archive, void const * data,
+    std::size_t size) {
+  // Writes to output stream without extra copy
+  archive.saveBinary(data, size);
+}
+
+template <class Archive>
+void loadBinary(Archive & archive, void * data, std::size_t size) {
+  // In general, there's no direct `loadBinary`-like method on archives
+  std::vector<char> v(size);
+  archive(v);
+  std::memcpy(data, v.data(), size);
+}
+template <>
+inline void loadBinary(BinaryInputArchive & archive, void * data, std::size_t size) {
+  // Read from input stream without extra copy
+  archive.loadBinary(data, size);
+}
+
+} // namespace agimpl
+
 // Gradients will not be saved for variables
 template <class Archive>
 void save(Archive & archive, at::Tensor const & tensor) {
@@ -483,7 +514,7 @@ void save(Archive & archive, at::Tensor const & tensor) {
   at::Backend backend = tensor.type().backend();
 
   archive(CEREAL_NVP(backend), CEREAL_NVP(sizes), CEREAL_NVP(size));
-  archive.saveBinary(contig.storage()->data(), size);
+  agimpl::saveBinary(archive, contig.storage()->data(), size);
 }
 
 /**
@@ -514,11 +545,11 @@ void load(Archive & archive, at::Tensor & tensor) {
     // should actually use cudamemcpy probably
     auto cputensor = at::CPU(tensor.type().scalarType()).tensor(sizes);
     tensor.resize_(sizes);
-    archive.loadBinary(cputensor.storage()->data(), size);
+    agimpl::loadBinary(archive, cputensor.storage()->data(), size);
     tensor.copy_(cputensor);
   } else {
     tensor.resize_(sizes);
-    archive.loadBinary(tensor.storage()->data(), size);
+    agimpl::loadBinary(archive, tensor.storage()->data(), size);
   }
 }
 

--- a/test.cpp
+++ b/test.cpp
@@ -2,6 +2,7 @@
 #include <map>
 #include <regex>
 #include <math.h>
+#include "cereal/archives/portable_binary.hpp"
 #include "autograd.h"
 using namespace autograd;
 
@@ -400,6 +401,44 @@ std::map<std::string, std::function<void()>> construct_tests() {
    load(ss, &y);
 
    EXPECT(!y.defined());
+ };
+
+ tests["autograd/serialization/binary"] = []() {
+   auto x = at::CPU(at::kFloat).randn({5, 5});
+   auto y = at::Tensor();
+
+   std::stringstream ss;
+   {
+     cereal::BinaryOutputArchive archive(ss);
+     archive(x);
+   }
+   {
+     cereal::BinaryInputArchive archive(ss);
+     archive(y);
+   }
+
+   EXPECT(y.defined());
+   EXPECT(x.sizes().vec() == y.sizes().vec());
+   EXPECT(x.eq(y).all());
+ };
+
+ tests["autograd/serialization/portable_binary"] = []() {
+   auto x = at::CPU(at::kFloat).randn({5, 5});
+   auto y = at::Tensor();
+
+   std::stringstream ss;
+   {
+     cereal::PortableBinaryOutputArchive archive(ss);
+     archive(x);
+   }
+   {
+     cereal::PortableBinaryInputArchive archive(ss);
+     archive(y);
+   }
+
+   EXPECT(y.defined());
+   EXPECT(x.sizes().vec() == y.sizes().vec());
+   EXPECT(x.eq(y).all());
  };
 
  tests["autograd/serialization/xor"] = []() {


### PR DESCRIPTION
The previous implementation did not compile if an application would also use
other archive formats (at least not for me on macOS). Hence, for maximum
flexibility, provide tensor serialization methods for all archive formats
offered by Cereal. For binary archives, we can use an efficient implementation
(the previous one) which avoids extra copies. For other archives, fall back to
serializing a vector<uint8_t> instead.