### PR TITLE
Updating RNN to include all types PyTorch has, and uses CUDNN

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ make -j
 AUTOGRAD_CONTAINER_CLASS(MyModel) {
   // This does a 2D convolution, followed by global sum pooling, followed by a linear.
  public:
-  void initialize_parameters() override {
+  void initialize_containers() override {
     myConv_ = add(Conv2d(1, 50, 3, 3).stride(2).make(), "conv");
     myLinear_ = add(Linear(50, 1).make(), "linear");
   }
@@ -42,7 +42,8 @@ AUTOGRAD_CONTAINER_CLASS(MyModel) {
 ```
 
 Some things are not implemented:
-- Batchnorm
-- SGD, Adagrad, RMSprop, and Adam are implemented: the rest of the optimizers are just copying Python code from PyTorch over.
+- SGD, Adagrad, RMSprop, and Adam are the only optimizers implemented
+- Bidirectional, batch first, and PackedSequence are not implemented for LSTMs
+- Sparse Tensors might work but are very untested
 
-Otherwise, everything else works. There may be breaking API changes.
+Otherwise, lots of other things work. There may be breaking API changes.

--- a/include/containers.h
+++ b/include/containers.h
@@ -12,7 +12,7 @@ class ContainerImpl {
   // Only construct parameters in initialize_parameters, and 
   // containers in initialize_containers. Most of the time, the containers are
   // the only thing you need to add.
-  // You are gauranteed that containers are added before parameters.
+  // You are guaranteed that containers are added before parameters.
   virtual void initialize_containers() { };
   virtual void initialize_parameters() { };
   virtual void reset_parameters() { };
@@ -20,7 +20,7 @@ class ContainerImpl {
   virtual variable_list forward(variable_list) = 0;
 
   std::map<std::string, Variable> parameters() const;
-  Variable param(std::string);
+  Variable& param(std::string);
 
   virtual void cuda();
   virtual void cpu();
@@ -305,7 +305,13 @@ class RNNBase : public Container_CRTP<Derived> {
   uint32_t input_size_;
   uint32_t hidden_size_;
   uint32_t gate_size_;
-  std::unordered_set<void*> data_ptrs_;
+  // This is copied from pytorch, to determine whether weights are flat for 
+  // the fast CUDNN route. Otherwise, we have to use non flattened weights, which
+  // are much slower.
+  // https://github.com/pytorch/pytorch/blob/1848cad10802db9fa0aa066d9de195958120d863/torch/nn/modules/rnn.py#L159-L165
+  // TODO Actually since we are in C++ we can probably just actually check if
+  // the parameters are flat, instead of relying on data pointers and stuff.
+  std::vector<void*> data_ptrs_;
   Variable flat_weight_;
   Container dropout_module;
 

--- a/include/containers.h
+++ b/include/containers.h
@@ -9,15 +9,21 @@
 namespace autograd {
 class ContainerImpl {
  public:
+  // Only construct parameters in initialize_parameters, and 
+  // containers in initialize_containers. Most of the time, the containers are
+  // the only thing you need to add.
+  // You are gauranteed that containers are added before parameters.
+  virtual void initialize_containers() { };
+  virtual void initialize_parameters() { };
   virtual void reset_parameters() { };
 
   virtual variable_list forward(variable_list) = 0;
-  virtual void initialize_parameters() { };
 
   std::map<std::string, Variable> parameters() const;
+  Variable param(std::string);
 
-  void cuda();
-  void cpu();
+  virtual void cuda();
+  virtual void cpu();
   void train();
   void eval();
 
@@ -61,6 +67,7 @@ class Container_CRTP : public ContainerImpl {
  public:
   std::shared_ptr<Derived> make() const {
     auto ptr = std::make_shared<Derived>(*static_cast<const Derived*>(this));
+    ptr->initialize_containers();
     ptr->initialize_parameters();
     ptr->reset_parameters();
     return ptr;
@@ -264,27 +271,88 @@ AUTOGRAD_CONTAINER_CLASS(Dropout2d) {
   double p_;
 };
 
-AUTOGRAD_CONTAINER_CLASS(LSTM) {
+template <typename Derived>
+class RNNBase : public Container_CRTP<Derived> {
  public:
-  LSTM(uint32_t input_size, uint32_t hidden_size)
+  // These must line up with the CUDNN mode codes
+  enum RNNMode : int64_t { 
+    RNN_RELU = 0,
+    RNN_TANH = 1,
+    LSTM = 2,
+    GRU = 3
+  };
+  RNNBase(uint32_t input_size, uint32_t hidden_size)
     : input_size_(input_size), hidden_size_(hidden_size) { }
 
-  AUTOGRAD_KWARG(LSTM, bool, no_bias, false, true)
-  AUTOGRAD_KWARG(LSTM, uint32_t, nlayers, false, true)
-  AUTOGRAD_KWARG(LSTM, double, dropout, false, true)
+  AUTOGRAD_KWARG(RNNBase, RNNMode, mode, RNNMode::LSTM, RNNMode::LSTM)
+  AUTOGRAD_KWARG(RNNBase, uint32_t, nlayers, 1, 1);
+  AUTOGRAD_KWARG(RNNBase, bool, no_bias, false, true)
+  AUTOGRAD_KWARG(RNNBase, float, dropout, 0, 0)
 
-  std::vector<Variable>& hiddens() { return hiddens_; }
+  bool flatten_parameters();  // Flatten for cudnn
 
-  void reset_parameters() override;
   variable_list forward(variable_list) override;
-  void initialize_parameters() override;
+  void initialize_containers() override;
+  void reset_parameters() override;
+
+  void cpu() override;
+  void cuda() override;
 
   std::vector<Container> i2h;
   std::vector<Container> h2h;
-  std::vector<Variable> hiddens_;
+
  protected:
   uint32_t input_size_;
   uint32_t hidden_size_;
+  uint32_t gate_size_;
+  std::unordered_set<void*> data_ptrs_;
+  Variable flat_weight_;
   Container dropout_module;
+
+  variable_list CUDNN_forward(variable_list);
+  variable_list autograd_forward(variable_list);
+
+  variable_list cell_forward(variable_list, int);
+  variable_list LSTM_cell_forward(variable_list, int);
+  variable_list GRU_cell_forward(variable_list, int);
+  variable_list RNN_RELU_cell_forward(variable_list, int);
+  variable_list RNN_TANH_cell_forward(variable_list, int);
 };
+
+// We must instantiate these templates so we can put implementations in the .cpp
+class LSTM;
+template class RNNBase<LSTM>;
+class LSTM : public RNNBase<LSTM> {
+ public:
+  LSTM(uint32_t inp_size, uint32_t hid_size) : RNNBase(inp_size, hid_size) {
+    mode_ = RNNBase::RNNMode::LSTM;
+  }
+};
+
+class GRU;
+template class RNNBase<GRU>;
+class GRU : public RNNBase<GRU> {
+ public:
+  GRU(uint32_t inp_size, uint32_t hid_size) : RNNBase(inp_size, hid_size) {
+    mode_ = RNNBase::RNNMode::GRU;
+  }
+};
+
+class RNN;
+template class RNNBase<RNN>;
+class RNN : public RNNBase<RNN> {
+ public:
+  enum Mode { Tanh, Relu };
+  RNN(uint32_t inp_size, uint32_t hid_size, Mode mode = Mode::Tanh) 
+    : RNNBase(inp_size, hid_size) {
+    if (mode == Mode::Tanh) {
+      mode_ = RNNBase::RNNMode::RNN_TANH;
+    } else if (mode == Mode::Relu) {
+      mode_ = RNNBase::RNNMode::RNN_RELU;
+    } else {
+      throw std::runtime_error("RNN Mode not supported");
+    }
+  }
+};
+
 } // namespace autograd

--- a/src/containers.cpp
+++ b/src/containers.cpp
@@ -16,6 +16,10 @@ std::map<std::string, Variable> ContainerImpl::parameters() const {
   return ret;
 }
 
+Variable ContainerImpl::param(std::string name) {
+  return params_[name];
+}
+
 void ContainerImpl::cuda() {
   for (auto& pair : children_) {
     pair.second->cuda();
@@ -29,6 +33,7 @@ void ContainerImpl::cuda() {
   cuda_ = true;
   // So we hack it...
   auto copied = params_;
+  params_.clear();
   initialize_parameters();
   for (auto pair : params_) {
     pair.second.data().copy_(copied[pair.first].data());
@@ -42,6 +47,7 @@ void ContainerImpl::cpu() {
   cuda_ = false;
   // So we hack it...
   auto copied = params_;
+  params_.clear();
   initialize_parameters();
   for (auto pair : params_) {
     pair.second.data().copy_(copied[pair.first].data());
@@ -63,11 +69,17 @@ void ContainerImpl::eval() {
 }
 
 Container ContainerImpl::add(Container m, std::string const& name) {
+  if (this->children_.find(name) != this->children_.end()) {
+    std::cerr << "Warning: Trying to add container that already exists" << std::endl;
+  }
   this->children_[name] = std::move(m);
   return this->children_[name];
 }
 
 Variable& ContainerImpl::add(Variable v, std::string const& name) {
+  if (this->params_.find(name) != this->params_.end()) {
+    std::cerr << "Warning: Trying to add parameter that already exists" << std::endl;
+  }
   this->params_[name] = v;
   return this->params_[name];
 }
@@ -234,62 +246,283 @@ variable_list BatchNorm::forward(variable_list inputs) {
   return variable_list({output});
 }
 
-void LSTM::initialize_parameters() {
-  i2h.clear();
-  h2h.clear();
-  auto gate_size = 4 * hidden_size_;
+template <typename Derived>
+void RNNBase<Derived>::initialize_containers() {
+  auto gate_size = hidden_size_;
+  if (mode_ == RNNMode::LSTM) {
+    gate_size *= 4;
+  } else if (mode_ == RNNMode::GRU) {
+    gate_size *= 3;
+  }
+
   for (auto i = 0U; i < nlayers_; i++) {
     auto input_size = (i == 0) ? input_size_ : hidden_size_;
-    hiddens_.push_back(tag::Variable());
-    i2h.push_back(add(Linear(input_size, gate_size).no_bias(no_bias_).make(), "h2h"));
-    h2h.push_back(add(Linear(hidden_size_, gate_size).no_bias(no_bias_).make(), "i2h"));
+    i2h.push_back(this->add(Linear(input_size, gate_size).no_bias(no_bias_).make(), "i2h_" + std::to_string(i)));
+    h2h.push_back(this->add(Linear(hidden_size_, gate_size).no_bias(no_bias_).make(), "h2h_" + std::to_string(i)));
   }
   if (dropout_ > 0) dropout_module = Dropout(dropout_).make();
+  this->flatten_parameters();
 }
 
-void LSTM::reset_parameters() {
+template <typename Derived>
+void RNNBase<Derived>::reset_parameters() {
   auto stdv = 1.0 / std::sqrt(hidden_size_);
-  for (auto& p : parameters()) {
+  for (auto& p : this->parameters()) {
     p.second.data().uniform_(-stdv, stdv);
   }
 }
 
-variable_list LSTM::forward(variable_list inputs) {
-  auto& inp = inputs[0];
-  auto bsz = inp.size(1);
-  for (auto i = 0U; i < nlayers_; i++) {
-    auto reset = false;
-    if (!hiddens_[i].defined()) {
-      reset = true;
-    } else if (bsz != hiddens_[i].size(0)) {
-      std::cerr << "Warning! Batch size doesn't match previous, resetting hiddens..." << std::endl;
-      reset = true;
-    }
-    if (reset) {
-      hiddens_[i] = Var(DefaultTensor(at::kFloat).zeros({inp.size(1), hidden_size_}));
-    }
+template <typename Derived>
+variable_list RNNBase<Derived>::GRU_cell_forward(variable_list inputs, int i) {
+  auto x = inputs[0];
+  auto hx = inputs[1].defined()
+    ? inputs[1]
+    : Var(this->DefaultTensor(at::kFloat).zeros({x.size(0), hidden_size_}));
+
+  auto gi = i2h[i]->forward({x})[0];
+  auto gh = h2h[i]->forward({hx})[0];
+  auto gic = gi.chunk(3, 1);
+  auto ghc = gh.chunk(3, 1);
+
+  auto reset_gate = (gic[0] + ghc[0]).sigmoid_();
+  auto input_gate = (gic[1] + ghc[1]).sigmoid_();
+  auto new_gate = (gic[2] + reset_gate * ghc[2]).tanh_();
+  auto hy = new_gate + input_gate * (hx - new_gate);
+
+  return variable_list({hy});
+}
+
+template <typename Derived>
+variable_list RNNBase<Derived>::RNN_TANH_cell_forward(variable_list inputs, int i) {
+  auto x = inputs[0];
+  auto hx = inputs[1].defined()
+    ? inputs[1]
+    : Var(this->DefaultTensor(at::kFloat).zeros({x.size(0), hidden_size_}));
+
+  auto h = (i2h[i]->forward({x})[0] + h2h[i]->forward({hx})[0]).tanh();
+  return variable_list({h});
+}
+
+template <typename Derived>
+variable_list RNNBase<Derived>::RNN_RELU_cell_forward(variable_list inputs, int i) {
+  auto x = inputs[0];
+  auto hx = inputs[1].defined()
+    ? inputs[1]
+    : Var(this->DefaultTensor(at::kFloat).zeros({x.size(0), hidden_size_}));
+
+  auto h = (i2h[i]->forward({x})[0] + h2h[i]->forward({hx})[0]).clamp_min(0);
+  return variable_list({h});
+}
+
+template <typename Derived>
+variable_list RNNBase<Derived>::LSTM_cell_forward(variable_list inputs, int i) {
+  auto x = inputs[0];
+  auto hid = inputs[1].defined()
+    ? inputs[1]
+    : Var(this->DefaultTensor(at::kFloat).zeros({2, x.size(0), hidden_size_}));
+  auto hx = hid[0];
+  auto cx = hid[1];
+
+  auto gates = i2h[i]->forward({x})[0] + h2h[i]->forward({hx})[0];
+
+  auto chunked = gates.chunk(4, 1);
+  auto in_gate = chunked[0].sigmoid();
+  auto forget_gate = chunked[1].sigmoid();
+  auto cell_gate = chunked[2].tanh();
+  auto out_gate = chunked[3].sigmoid();
+
+  auto cy = (forget_gate * cx) + (in_gate * cell_gate);
+  auto hy = out_gate * cy.tanh();
+
+  return variable_list({at::stack({hy, cy}, 0)}); 
+}
+
+template <typename Derived>
+variable_list RNNBase<Derived>::cell_forward(variable_list inputs, int i) {
+  if (mode_ == RNNMode::LSTM) return LSTM_cell_forward(inputs, i);
+  else if (mode_ == RNNMode::GRU) return GRU_cell_forward(inputs, i);
+  else if (mode_ == RNNMode::RNN_TANH) return RNN_TANH_cell_forward(inputs, i);
+  else if (mode_ == RNNMode::RNN_RELU) return RNN_RELU_cell_forward(inputs, i);
+  else throw std::runtime_error("No such RNN mode");
+}
+
+template <typename Derived>
+variable_list RNNBase<Derived>::autograd_forward(variable_list inputs) {
+  auto inp = inputs[0];
+
+  std::vector<Tensor> hidden;
+  for (auto i = 0; i < nlayers_; i++) {
+    hidden.push_back(inputs[1].defined() 
+        ? inputs[1][i] 
+        : tag::Variable());
   }
-  auto output = Var(DefaultTensor(at::kFloat).zeros({inp.size(0), inp.size(1), hidden_size_}));
+
+  auto output = Var(this->DefaultTensor(at::kFloat).zeros({inp.size(0), inp.size(1), hidden_size_}), false);
   for (auto t = 0U; t < inp.size(0); t++ ) {
     auto x = inp.select(0, t);
-    for (auto i = 0U; i < nlayers_; i++) {
-      auto hid = hiddens_[i];
-      auto gates = i2h[i]->forward({x})[0] + h2h[i]->forward({hid})[0];
-      gates = gates.view({bsz, 4, hidden_size_});
-      auto in_gate = gates.select(1, 0).sigmoid();
-      auto in_trans = gates.select(1, 1).tanh();
-      auto forget_gate = gates.select(1, 2).sigmoid();
-      auto out_gate = gates.select(1, 3).sigmoid();
-      x = forget_gate * hid + in_gate * in_trans;
-      hiddens_[i] = out_gate * x.tanh();
-    }
-    auto output_slice = output.select(0, t);
-    output_slice.copy_(x);
-    if (dropout_ > 0 && t != inp.size(0) - 1) {
-      output = dropout_module->forward({output})[0];
+    for (size_t i = 0; i < nlayers_; i++) {
+      auto layer_output = cell_forward({x, hidden[i]}, i);
+      hidden[i] = layer_output[0];
+      if (mode_ == RNNMode::LSTM) {
+        x = hidden[i][0];
+      } else {
+        x = hidden[i];
+      }
+      auto output_slice = output.select(0, t);
+      output_slice.copy_(x);
+      if (dropout_ > 0 && i != nlayers_ - 1) {
+        x = dropout_module->forward({x})[0];
+      }
     }
   }
-  return variable_list({output});
+
+  auto hidout = at::stack(hidden, 0);
+  return variable_list({output, hidout});
+}
+
+template <typename Derived>
+bool RNNBase<Derived>::flatten_parameters() {
+  data_ptrs_.clear();
+  auto anyParam = i2h[0]->params_.begin()->second;
+  if (!anyParam.is_cuda() || !at::cudnn_is_acceptable(anyParam)) {
+    return false;
+  }
+  std::unordered_set<void*> unique_data_ptrs;
+  auto params = this->parameters();
+  for (auto& p : params) {
+    unique_data_ptrs.insert(p.second.data().data_ptr());
+  }
+  // TODO PyTorch says:
+  // If any parameters alias, we fall back to the slower, copying code path. This is
+  // a sufficient check, because overlapping parameter buffers that don't completely
+  // alias would break the assumptions of the uniqueness check in
+  // Module.named_parameters().
+  // But I'm not sure if this is the case for us
+  if (unique_data_ptrs.size() != params.size()) {
+    return false;
+  }
+
+  std::vector<Tensor> weight_list;
+  for (auto i = 0; i < nlayers_; i++) {
+    weight_list.push_back(i2h[i]->param("weight"));
+    weight_list.push_back(h2h[i]->param("weight"));
+    if (!no_bias_) {
+      weight_list.push_back(i2h[i]->param("bias"));
+      weight_list.push_back(h2h[i]->param("bias"));
+    }
+  }
+  auto weight_stride0 = no_bias_ ? 2 : 4;
+
+  {
+    no_grad_guard guard;
+    flat_weight_ = at::_cudnn_rnn_flatten_weight(
+      weight_list,
+      weight_stride0,
+      input_size_,
+      mode_,
+      hidden_size_,
+      nlayers_,
+      false,
+      false); // batch_first and bidirectional, unsupported
+  }
+  for (auto& p : params) {
+    data_ptrs_.insert(p.second.data().data_ptr());
+  }
+  return true;
+}
+
+template <typename Derived>
+variable_list RNNBase<Derived>::CUDNN_forward(variable_list inputs) {
+  std::vector<Tensor> weight_list;
+  for (auto i = 0; i < nlayers_; i++) {
+    weight_list.push_back(i2h[i]->param("weight"));
+    weight_list.push_back(h2h[i]->param("weight"));
+    if (!no_bias_) {
+      weight_list.push_back(i2h[i]->param("bias"));
+      weight_list.push_back(h2h[i]->param("bias"));
+    }
+  }
+  auto weight_stride0 = no_bias_ ? 2 : 4;
+
+  auto x = inputs[0];
+  Variable hx, cx;
+  if (!inputs[1].defined()) {
+    hx = x.type().zeros({nlayers_, x.size(1), hidden_size_});
+    if (mode_ == RNNMode::LSTM) {
+      cx = x.type().zeros({nlayers_, x.size(1), hidden_size_});
+    }
+  } else {
+    hx = mode_ == RNNMode::LSTM ? inputs[1][0] : inputs[1];
+    cx = mode_ == RNNMode::LSTM ? inputs[1][1] : Variable();
+  }
+  auto dropout_state = x.type().tensor();
+
+  std::unordered_set<void*> unique_data_ptrs;
+  auto params = this->parameters();
+  for (auto& p : params) {
+    unique_data_ptrs.insert(p.second.data().data_ptr());
+  }
+  if (unique_data_ptrs != data_ptrs_) {
+    std::cerr << "Parameters are unflattened! Code path might be super slow. "
+      "Please call flatten_parameters() when you muck around with storages!"
+      << std::endl;
+    flat_weight_ = Variable();
+  }
+
+  // tup = std::tuple of output, hy, cy, reserve, new_weight_buf
+  auto tup = _cudnn_rnn(
+      x,
+      weight_list,
+      weight_stride0,
+      flat_weight_,
+      hx,
+      cx,
+      mode_,
+      hidden_size_,
+      nlayers_,
+      false, // batch first
+      0, // TODO waiting on dropout state descriptor in C++ pytorch
+      this->train_,
+      false, // bidirectional
+      {}, // packing not supported
+      dropout_state // TODO waiting on dropout state descriptor in C++ pytorch
+      );
+
+  Variable hidout = mode_ == RNNMode::LSTM
+    ? at::stack({std::get<1>(tup), std::get<2>(tup)}, 0)
+    : std::get<1>(tup);
+  Variable output = std::get<0>(tup);
+  return variable_list({output, hidout});
+}
+
+template <typename Derived>
+variable_list RNNBase<Derived>::forward(variable_list inputs) {
+  variable_list inp;
+  inp.push_back(inputs[0]);
+  if (inputs.size() > 1) {
+    inp.push_back(inputs[1]);
+  } else {
+    inp.push_back(Variable());
+  }
+
+  // Dropout descriptors aren't in C++ in PyTorch yet...
+  auto output = at::cudnn_is_acceptable(inp[0]) && dropout_ == 0
+    ? CUDNN_forward(inp)
+    : autograd_forward(inp);
+
+  return output;
+}
+
+template <typename Derived>
+void RNNBase<Derived>::cuda() {
+  Container_CRTP<Derived>::cuda();
+  flatten_parameters();
+}
+
+template <typename Derived>
+void RNNBase<Derived>::cpu() {
+  Container_CRTP<Derived>::cpu();
+  flatten_parameters();
 }
 
 variable_list Dropout::forward(variable_list inputs) {

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -107,6 +107,58 @@ class CartPole {
     };
 };
 
+template <typename R, typename Func>
+void test_RNN_xor(Func model_maker, bool cuda = false) {
+  auto nhid = 32;
+  auto model = SimpleContainer().make();
+  auto l1 = model->add(Linear(1, nhid).make(), "l1");
+  auto rnn = model->add(model_maker(nhid), "rnn");
+  auto lo = model->add(Linear(nhid, 1).make(), "lo");
+
+  auto optim = Adam(model, 1e-2).make();
+
+  auto forward_op = [&](Variable x) {
+    auto T = x.size(0);
+    auto B = x.size(1);
+    x = x.view({T * B, 1});
+    x = l1->forward({x})[0].view({T, B, nhid}).tanh_();
+    x = rnn->forward({x})[0][T-1];
+    x = lo->forward({x})[0];
+    return x;
+  };
+
+  if (cuda) {
+    model->cuda();
+  }
+
+  float running_loss = 1;
+  int epoch = 0;
+  while (running_loss > 1e-2) {
+    auto bs = 16U;
+    auto nlen = 5U;
+    auto inp = at::CPU(at::kFloat).rand({nlen, bs, 1}).round().toType(at::kFloat);
+    auto lab = inp.sum(0);
+
+    if (cuda) {
+      inp = inp.toBackend(at::kCUDA);
+      lab = lab.toBackend(at::kCUDA);
+    }
+
+    auto x = Var(inp);
+    auto y = Var(lab, false);
+    x = forward_op(x);
+    Variable loss = at::mse_loss(x, y);
+
+    optim->zero_grad();
+    backward(loss);
+    optim->step();
+
+    running_loss = running_loss * 0.99 + loss.toCFloat() * 0.01;
+    EXPECT(epoch < 1500);
+    epoch++;
+  }
+};
+
 void test_optimizer_xor(Optimizer optim, std::shared_ptr<ContainerList> model) {
    float running_loss = 1;
    int epoch = 0;
@@ -351,11 +403,14 @@ std::map<std::string, std::function<void()>> construct_tests() {
    EXPECT(y.data().sum().toCFloat() == 100);
  };
 
- tests["autograd/LSTM/1"] = []() {
+ tests["autograd/RNN/LSTM/sizes"] = []() {
    auto model = LSTM(128, 64).nlayers(2).dropout(0.2).make();
    Variable x = Var(at::CPU(at::kFloat).randn({10, 16, 128}));
-   auto out = model->forward({x})[0];
+   auto tup = model->forward({x});
    auto y = x.mean();
+
+   auto out = tup[0];
+   auto hids = tup[1];
 
    backward(y);
    EXPECT(out.ndimension() == 3);
@@ -363,23 +418,64 @@ std::map<std::string, std::function<void()>> construct_tests() {
    EXPECT(out.size(1) == 16);
    EXPECT(out.size(2) == 64);
 
-   EXPECT(model->hiddens()[0].ndimension() == 2);
-   EXPECT(model->hiddens()[0].size(0) == 16);
-   EXPECT(model->hiddens()[0].size(1) == 64);
-   EXPECT(model->hiddens()[1].ndimension() == 2);
-   EXPECT(model->hiddens()[1].size(0) == 16);
-   EXPECT(model->hiddens()[1].size(1) == 64);
+   EXPECT(hids.ndimension() == 4);
+   EXPECT(hids.size(0) == 2);  // 2 layers
+   EXPECT(hids.size(1) == 2);  // c and h
+   EXPECT(hids.size(2) == 16); // Batch size of 16
+   EXPECT(hids.size(3) == 64); // 64 hidden dims
 
    // Something is in the hiddens
-   EXPECT(model->hiddens()[0].data().norm().toCFloat() > 0);
-   EXPECT(model->hiddens()[1].data().norm().toCFloat() > 0);
+   EXPECT(hids.norm().toCFloat() > 0);
 
-   Variable saved_hidden = model->hiddens()[0];
-   model->forward({x})[0];
-   Variable diff = model->hiddens()[0] - saved_hidden;
+   Variable diff = model->forward({x, hids})[1] - hids;
 
    // Hiddens changed
    EXPECT(diff.data().abs().sum().toCFloat() > 1e-3)
+ };
+
+ tests["autograd/RNN/LSTM/outputs"] = []() {
+   // Make sure the outputs match pytorch outputs
+   auto model = LSTM(2, 2).make();
+   for (auto& v : model->parameters()) {
+     float size = v.second.numel();
+     auto p = static_cast<float*>(v.second.data().storage()->data());
+     for (size_t i = 0; i < size; i++) {
+       p[i] = i/size;
+     }
+   }
+
+   Variable x = Var(at::CPU(at::kFloat).tensor({3, 4, 2}));
+   float size = x.data().numel();
+   auto p = static_cast<float*>(x.data().storage()->data());
+   for (size_t i = 0; i < size; i++) {
+     p[i] = (size - i) / size;
+   }
+  
+   auto out = model->forward({x});
+   EXPECT(out[0].ndimension() == 3);
+   EXPECT(out[0].size(0) == 3);
+   EXPECT(out[0].size(1) == 4);
+   EXPECT(out[0].size(2) == 2);
+
+   auto flat = out[0].data().view(3*4*2);
+   float c_out[] =  {0.4391, 0.5402, 0.4330, 0.5324, 0.4261, 0.5239, 0.4183, 
+     0.5147, 0.6822, 0.8064, 0.6726, 0.7968, 0.6620, 0.7860, 0.6501, 0.7741, 
+     0.7889, 0.9003, 0.7769, 0.8905, 0.7635, 0.8794, 0.7484, 0.8666};
+   for (size_t i = 0; i < 3*4*2; i++) {
+     EXPECT(std::abs(flat[i].toCFloat() - c_out[i]) < 1e-3);
+   }
+
+   EXPECT(out[1].ndimension() == 4); // T x (hx, cx) x B x 2
+   EXPECT(out[1].size(0) == 1);
+   EXPECT(out[1].size(1) == 2);
+   EXPECT(out[1].size(2) == 4);
+   EXPECT(out[1].size(3) == 2);
+   flat = out[1].data().view(16);
+   float h_out[] = {0.7889, 0.9003, 0.7769, 0.8905, 0.7635, 0.8794, 0.7484,
+     0.8666, 1.1647, 1.6106, 1.1425, 1.5726, 1.1187, 1.5329, 1.0931, 1.4911};
+   for (size_t i = 0; i < 16; i++) {
+     EXPECT(std::abs(flat[i].toCFloat() - h_out[i]) < 1e-3);
+   }
  };
 
  tests["autograd/optim/sgd"] = []() {
@@ -879,6 +975,37 @@ tests["autograd/~integration/cartpole"] = []() {
 
 };
 
+tests["autograd/~RNN/LSTM"] = [&]() {
+   test_RNN_xor<LSTM>([](int s) { return LSTM(s, s).nlayers(2).make(); });
+};
+
+tests["autograd/~RNN/GRU"] = [&]() {
+   test_RNN_xor<GRU>([](int s) { return GRU(s, s).nlayers(2).make(); });
+};
+
+tests["autograd/~RNN/RNN/Relu"] = [&]() {
+   test_RNN_xor<RNN>([](int s) { return RNN(s, s, RNN::Mode::Relu).nlayers(2).make(); });
+};
+
+tests["autograd/~RNN/RNN/Tanh"] = [&]() {
+   test_RNN_xor<RNN>([](int s) { return RNN(s, s, RNN::Mode::Tanh).nlayers(2).make(); });
+};
+
+tests["autograd/~RNN/cuda/LSTM"] = [&]() {
+   test_RNN_xor<LSTM>([](int s) { return LSTM(s, s).nlayers(2).make(); }, true);
+};
+
+tests["autograd/~RNN/cuda/GRU"] = [&]() {
+   test_RNN_xor<GRU>([](int s) { return GRU(s, s).nlayers(2).make(); }, true);
+};
+
+tests["autograd/~RNN/cuda/RNN/Relu"] = [&]() {
+   test_RNN_xor<RNN>([](int s) { return RNN(s, s, RNN::Mode::Relu).nlayers(2).make(); }, true);
+};
+
+tests["autograd/~RNN/cuda/RNN/Tanh"] = [&]() {
+   test_RNN_xor<RNN>([](int s) { return RNN(s, s, RNN::Mode::Tanh).nlayers(2).make(); }, true);
+};
 tests["autograd/random/seed_cpu"] = []() {
   int size = 100;
   setSeed(7);


### PR DESCRIPTION
Changes:

- Separate initialize_containers and initialize_parameters to show correct usage. If you don't, then the options framework won't work, since sometimes container construction requires options to be set (`LSTM(2, 2).nlayers().make()`). This implies the correct usage more.
- Added GRUs, LSTMs, and RNNs with a tanh or relu nonlinearity
- Tests LSTMs against pytorch implementation, and tests all against a stupid counting example (number of 1s in a string of 5 binary numbers)

Unimplemented:
- Bidirectional
- Batch first
- Fused non-CUDNN CUDA kernels (not bound in PyTorch ATen)
- PackedSequence