### PR TITLE
Fixes for macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,10 +57,12 @@ ADD_CUSTOM_COMMAND(
   TARGET autogradpp PRE_BUILD
   COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/pytorch/build/lib*/torch/lib/libshm.*" "${CMAKE_BINARY_DIR}/lib"
 )
-ADD_CUSTOM_COMMAND(
-  TARGET autogradpp PRE_BUILD
-  COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/pytorch/build/lib*/torch/lib/libgloo*" "${CMAKE_BINARY_DIR}/lib"
-)
+IF(NOT APPLE)
+  ADD_CUSTOM_COMMAND(
+    TARGET autogradpp PRE_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/pytorch/build/lib*/torch/lib/libgloo*" "${CMAKE_BINARY_DIR}/lib"
+  )
+ENDIF(NOT APPLE)
 ADD_LIBRARY(libpythpp SHARED IMPORTED)
 SET_TARGET_PROPERTIES(libpythpp PROPERTIES IMPORTED_NO_SONAME 1
   IMPORTED_LOCATION "${CMAKE_BINARY_DIR}/libpythpp.so")

--- a/tests/integration_t.cpp
+++ b/tests/integration_t.cpp
@@ -143,7 +143,7 @@ bool test_mnist(uint32_t batch_size, uint32_t num_epochs, bool useGPU,
      int label_count = rd.read_int();
 
      auto data = at::CPU(at::kLong).tensor({label_count});
-     auto a_data = data.accessor<long, 1>();
+     auto a_data = data.accessor<int64_t, 1>();
 
      for (int i = 0; i < label_count; ++i) {
        a_data[i] = long(rd.read_byte());


### PR DESCRIPTION
- Don't copy non-existent libgloo on macOS (gloo doesn't support macOS)
- Fix MNIST example on macOS (there's no `data<long>()` method and clang does not automatically pick up the `int64_t` one.)