### PR TITLE
Added Sequential Container class.

### DIFF
--- a/include/autogradpp/containers.h
+++ b/include/autogradpp/containers.h
@@ -108,6 +108,50 @@ public:
   std::vector<Container> children_;
 };
 
+AUTOGRAD_CONTAINER_CLASS(Sequential) {
+  // Mimics nn.Sequential from pytorch.
+  // Basically a copy of ContainerList with a forward method implemented, and
+  // the option to supply a custom name when adding containers.
+ public:
+  ag::variable_list forward(ag::variable_list input) override {
+    for (auto& container : children_) {
+      input = container->forward(input);
+    }
+    return input;
+  };
+
+  ag::Container add(ag::Container m, std::string name = "") {
+    return append(m, name).children_.back();
+  }
+
+  Sequential& append(ag::Container m, std::string name = "") {
+    if (name == "") {
+      name = std::to_string(size());
+    }
+    this->children_.push_back(m);
+    ContainerImpl::add(this->children_.back(), name);
+    return *this;
+  }
+
+  ag::Container& operator[](int index) {
+    return children_[index];
+  }
+
+  int size() {
+    return children_.size();
+  }
+
+  auto begin() {
+    return children_.begin();
+  }
+
+  auto end() {
+    return children_.end();
+  }
+
+  std::vector<ag::Container> children_;
+};
+
 AUTOGRAD_CONTAINER_CLASS(SimpleContainer) {
   // Lets you use a container without making a new class,
   // for experimental implementations

--- a/include/autogradpp/containers.h
+++ b/include/autogradpp/containers.h
@@ -75,7 +75,7 @@ class Container_CRTP : public ContainerImpl {
 };
 
 template <class Derived>
-class ContainerList : public Container_CRTP<Derived> {
+class ContainerListImpl : public Container_CRTP<Derived> {
   // Lets you use a container like a vector without making a new class,
   // just for simple implementations
  public:
@@ -89,8 +89,8 @@ class ContainerList : public Container_CRTP<Derived> {
     return append(m).children_.back();
   }
 
-  ContainerList<Derived>& append(Container m) {
-    this->children_.push_back(m);
+  ContainerListImpl<Derived>& append(Container m) {
+    children_.push_back(m);
     ContainerImpl::add(children_.back(), std::to_string(size() - 1));
     return *this;
   }
@@ -114,7 +114,9 @@ class ContainerList : public Container_CRTP<Derived> {
   std::vector<Container> children_;
 };
 
-class Sequential : public ContainerList<Sequential> {
+class ContainerList : public ContainerListImpl<ContainerList> {};
+
+class Sequential : public ContainerListImpl<Sequential> {
   // Mimics nn.Sequential from pytorch.
  public:
   variable_list forward(variable_list input) override {
@@ -132,7 +134,7 @@ class Sequential : public ContainerList<Sequential> {
     if (name == "") {
       name = std::to_string(size());
     }
-    this->children_.push_back(m);
+    children_.push_back(m);
     ContainerImpl::add(children_.back(), name);
     return *this;
   }


### PR DESCRIPTION
Added the Sequential Container class, which aims to mimic pytorch's nn.Sequential behavior.
This involves copying code from the ContainerList container, as it can't be derived from: append or make would return a ContainerList instead of a Sequential. There's probably a better way to do it, but I don't know how.