### PR TITLE
Parameters functional

### DIFF
--- a/include/autogradpp/containers.h
+++ b/include/autogradpp/containers.h
@@ -4,48 +4,49 @@
 
 #include "torch/csrc/autograd/variable.h"
 
-#define AUTOGRAD_CONTAINER_CLASS(Type)                                         \
-  class Type : public autograd::Container_CRTP<Type>
+#define AUTOGRAD_CONTAINER_CLASS(Type) class Type : public autograd::Container_CRTP<Type>
 
 namespace autograd {
 class ContainerImpl {
-public:
+ public:
   // Only construct parameters in initialize_parameters, and
   // containers in initialize_containers. Most of the time, the containers are
   // the only thing you need to add.
   // You are guaranteed that containers are added before parameters.
-  virtual void initialize_containers(){};
-  virtual void initialize_parameters(){};
-  virtual void reset_parameters(){};
+  virtual void initialize_containers() { };
+  virtual void initialize_parameters() { };
+  virtual void reset_parameters() { };
 
   virtual variable_list forward(variable_list) = 0;
   virtual Container clone() const = 0;
 
   std::map<std::string, Variable> parameters() const;
-  Variable &param(std::string const &);
+  Variable& param(std::string const&);
 
   virtual void cuda();
   virtual void cpu();
   void train();
   void eval();
 
-  at::Type &DefaultTensor(at::ScalarType s);
+  at::Type& DefaultTensor(at::ScalarType s);
 
   std::unordered_map<std::string, Container> children_;
   std::unordered_map<std::string, Variable> params_;
   bool cuda_ = false;
   bool train_ = true;
 
-  template <class Archive> void save(Archive &ar) const {
+  template<class Archive>
+  void save(Archive & ar) const {
     auto params = parameters();
     std::size_t size = params.size();
     ar(size);
-    for (auto &p : params) {
+    for (auto& p : params) {
       ar(p.first, p.second);
     }
   }
 
-  template <class Archive> void load(Archive &ar) {
+  template<class Archive>
+  void load(Archive & ar) {
     auto params = parameters();
     std::size_t size;
     ar(size);
@@ -56,16 +57,17 @@ public:
     }
   }
 
-protected:
-  Container add(Container, std::string const &);
+ protected:
+  Container add(Container, std::string const&);
   // Be careful when registering Tensors that are not variables
-  Variable &add(Variable, std::string const &);
+  Variable& add(Variable, std::string const&);
 };
 
-template <class Derived> class Container_CRTP : public ContainerImpl {
-public:
+template <class Derived>
+class Container_CRTP : public ContainerImpl {
+ public:
   std::shared_ptr<Derived> make() const {
-    auto ptr = std::make_shared<Derived>(*static_cast<const Derived *>(this));
+    auto ptr = std::make_shared<Derived>(*static_cast<const Derived*>(this));
     ptr->initialize_containers();
     ptr->initialize_parameters();
     ptr->reset_parameters();
@@ -73,13 +75,13 @@ public:
   }
 
   Container clone() const override {
-    auto ptr = std::make_shared<Derived>(*static_cast<const Derived *>(this));
+    auto ptr = std::make_shared<Derived>(*static_cast<const Derived*>(this));
     ptr->children_.clear();
     ptr->params_.clear();
     ptr->initialize_containers();
     ptr->initialize_parameters();
     auto newParams = ptr->parameters();
-    for (auto &param : parameters()) {
+    for (auto& param : parameters()) {
       newParams[param.first].data().copy_(param.second.data());
     }
     return ptr;
@@ -90,27 +92,38 @@ template <class Derived>
 class ContainerListImpl : public Container_CRTP<Derived> {
   // Lets you use a container like a vector without making a new class,
   // just for simple implementations
-public:
+ public:
   virtual variable_list forward(variable_list) override {
-    throw std::runtime_error("ContainerList has no forward, maybe you"
-                             " wanted to subclass and override this function?");
+    throw std::runtime_error(
+        "ContainerList has no forward, maybe you"
+        " wanted to subclass and override this function?");
   }
 
-  Container add(Container m) { return append(m).children_.back(); }
+  Container add(Container m) {
+    return append(m).children_.back();
+  }
 
-  ContainerListImpl<Derived> &append(Container m) {
+  ContainerListImpl<Derived>& append(Container m) {
     children_.push_back(m);
     ContainerImpl::add(children_.back(), std::to_string(size() - 1));
     return *this;
   }
 
-  Container &operator[](int index) { return children_[index]; }
+  Container& operator[](int index) {
+    return children_[index];
+  }
 
-  int size() { return children_.size(); }
+  int size() {
+    return children_.size();
+  }
 
-  auto begin() { return children_.begin(); }
+  auto begin() {
+    return children_.begin();
+  }
 
-  auto end() { return children_.end(); }
+  auto end() {
+    return children_.end();
+  }
 
   std::vector<Container> children_;
 };
@@ -119,9 +132,9 @@ class ContainerList : public ContainerListImpl<ContainerList> {};
 
 class Sequential : public ContainerListImpl<Sequential> {
   // Mimics nn.Sequential from pytorch.
-public:
+ public:
   variable_list forward(variable_list input) override {
-    for (auto &container : children_) {
+    for (auto& container : children_) {
       input = container->forward(input);
     }
     return input;
@@ -131,7 +144,7 @@ public:
     return append(m, name).children_.back();
   }
 
-  Sequential &append(Container m, std::string name = "") {
+  Sequential& append(Container m, std::string name = "") {
     if (name == "") {
       name = std::to_string(size());
     }
@@ -144,12 +157,13 @@ public:
 AUTOGRAD_CONTAINER_CLASS(SimpleContainer) {
   // Lets you use a container without making a new class,
   // for experimental implementations
-public:
+ public:
   virtual variable_list forward(variable_list) override {
     throw std::runtime_error("SimpleContainer has no forward, maybe you"
-                             " wanted to subclass and override this function?");
+        " wanted to subclass and override this function?");
   }
   using ContainerImpl::add;
+
 };
 
 AUTOGRAD_CONTAINER_CLASS(Functional) {
@@ -166,121 +180,121 @@ public:
 };
 
 AUTOGRAD_CONTAINER_CLASS(Linear) {
-public:
-  Linear(uint32_t nin, uint32_t nout) : nin(nin), nout(nout) {}
+ public:
+   Linear(uint32_t nin, uint32_t nout)
+     : nin(nin), nout(nout) { }
 
-  variable_list forward(variable_list) override;
-  void reset_parameters() override;
-  void initialize_parameters() override;
-  AUTOGRAD_KWARG(Linear, bool, no_bias, false, true);
+   variable_list forward(variable_list) override;
+   void reset_parameters() override;
+   void initialize_parameters() override;
+   AUTOGRAD_KWARG(Linear, bool, no_bias, false, true);
 
   Variable weight, bias;
   uint32_t nin, nout;
 };
 
 AUTOGRAD_CONTAINER_CLASS(Embedding) {
-public:
-  Embedding(uint32_t num_embeddings, uint32_t embedding_dim)
-      : num_embeddings(num_embeddings), embedding_dim(embedding_dim) {}
+ public:
+   Embedding(uint32_t num_embeddings, uint32_t embedding_dim)
+     : num_embeddings(num_embeddings), embedding_dim(embedding_dim) { }
 
-  variable_list forward(variable_list) override;
-  void reset_parameters() override;
-  void initialize_parameters() override;
+   variable_list forward(variable_list) override;
+   void reset_parameters() override;
+   void initialize_parameters() override;
 
   Variable weight;
   uint32_t num_embeddings, embedding_dim;
 };
 
 AUTOGRAD_CONTAINER_CLASS(Conv) {
-private:
+ private:
   Conv(uint32_t Nd, uint32_t in_chan, uint32_t out_chan)
-      : Nd_(Nd), in_channels_(in_chan), out_channels_(out_chan),
-        stride_(makeTup(1, 1)), padding_(makeTup(0)), dilation_(makeTup(1, 1)),
-        dilated_(false), output_padding_(makeTup(0)) {}
+    : Nd_(Nd),
+      in_channels_(in_chan),
+      out_channels_(out_chan),
+      stride_(makeTup(1, 1)),
+      padding_(makeTup(0)),
+      dilation_(makeTup(1, 1)),
+      dilated_(false),
+      output_padding_(makeTup(0))
+      { }
 
-public:
+ public:
   Conv(uint32_t Nd, uint32_t in_chan, uint32_t out_chan, int ks)
-      : Conv(Nd, in_chan, out_chan) {
-    ks_ = makeTup(ks, 1);
-  }
+    : Conv(Nd, in_chan, out_chan) {
+      ks_ = makeTup(ks, 1);
+    }
 
   Conv(uint32_t Nd, uint32_t in_chan, uint32_t out_chan, IntVec ks)
-      : Conv(Nd, in_chan, out_chan) {
-    ks_ = makeTup(ks);
-  }
+    : Conv(Nd, in_chan, out_chan) {
+      ks_ = makeTup(ks);
+    }
 
   void reset_parameters() override;
   variable_list forward(variable_list) override;
   void initialize_parameters() override;
 
-  template <typename T> Conv &stride(T s) {
-    stride_ = makeTup(s, 1);
-    return *this;
-  }
-  template <typename T> Conv &padding(T s) {
-    padding_ = makeTup(s);
-    return *this;
-  }
-  template <typename T> Conv &dilation(T s) {
-    dilation_ = makeTup(s, 1);
-    return *this;
-  }
-  template <typename T> Conv &output_padding(T s) {
-    output_padding_ = makeTup(s);
-    return *this;
-  }
+  template <typename T>
+  Conv& stride(T s) { stride_ = makeTup(s, 1); return *this; }
+  template <typename T>
+  Conv& padding(T s) { padding_ = makeTup(s); return *this; }
+  template <typename T>
+  Conv& dilation(T s) { dilation_ = makeTup(s, 1); return *this; }
+  template <typename T>
+  Conv& output_padding(T s) { output_padding_ = makeTup(s); return *this; }
 
   AUTOGRAD_KWARG(Conv, bool, transposed, false, true)
   AUTOGRAD_KWARG(Conv, bool, no_bias, false, true)
   AUTOGRAD_KWARG(Conv, int, groups, 1, 1)
 
-  Variable weight, bias;
-  uint32_t Nd_;
-  uint32_t in_channels_;
-  uint32_t out_channels_;
-  IntVec ks_;
-  IntVec stride_;
-  IntVec padding_;
-  IntVec dilation_;
-  bool dilated_;
-  IntVec output_padding_;
-
-protected:
-  IntVec makeTup(int x, int def = 0) {
-    IntVec ret;
-    if (Nd_ == 1) {
-      ret.push_back(x);
-      ret.push_back(def);
-    } else {
-      for (auto i = 0U; i < Nd_; i++)
-        ret.push_back(x);
-    }
-    return ret;
-  }
-  IntVec makeTup(IntVec x) { return x; }
+   Variable weight, bias;
+   uint32_t Nd_;
+   uint32_t in_channels_;
+   uint32_t out_channels_;
+   IntVec ks_;
+   IntVec stride_;
+   IntVec padding_;
+   IntVec dilation_;
+   bool dilated_;
+   IntVec output_padding_;
+  protected:
+   IntVec makeTup(int x, int def=0) {
+     IntVec ret;
+     if (Nd_ == 1) {
+       ret.push_back(x);
+       ret.push_back(def);
+     } else {
+       for (auto i = 0U; i < Nd_; i++) ret.push_back(x);
+     }
+     return ret;
+   }
+   IntVec makeTup(IntVec x) {
+     return x;
+   }
 };
 
 class Conv1d : public Conv {
-public:
-  Conv1d(uint32_t i, uint32_t o, int ks) : Conv(1, i, o, ks) {}
-  Conv1d(uint32_t i, uint32_t o, IntVec ks) : Conv(1, i, o, ks) {}
+ public:
+  Conv1d(uint32_t i, uint32_t o, int ks) : Conv(1, i, o, ks) { }
+  Conv1d(uint32_t i, uint32_t o, IntVec ks) : Conv(1, i, o, ks) { }
 };
 
 class Conv2d : public Conv {
-public:
-  Conv2d(uint32_t i, uint32_t o, int ks) : Conv(2, i, o, ks) {}
-  Conv2d(uint32_t i, uint32_t o, IntVec ks) : Conv(2, i, o, ks) {}
+ public:
+  Conv2d(uint32_t i, uint32_t o, int ks) : Conv(2, i, o, ks) { }
+  Conv2d(uint32_t i, uint32_t o, IntVec ks) : Conv(2, i, o, ks) { }
 };
 
 class Conv3d : public Conv {
-public:
-  Conv3d(uint32_t i, uint32_t o, int ks) : Conv(3, i, o, ks) {}
-  Conv3d(uint32_t i, uint32_t o, IntVec ks) : Conv(3, i, o, ks) {}
+ public:
+  Conv3d(uint32_t i, uint32_t o, int ks) : Conv(3, i, o, ks) { }
+  Conv3d(uint32_t i, uint32_t o, IntVec ks) : Conv(3, i, o, ks) { }
 };
 
 AUTOGRAD_CONTAINER_CLASS(BatchNorm) {
-public:
-  BatchNorm(uint32_t num_features) : num_features_(num_features) {}
+ public:
+  BatchNorm(uint32_t num_features)
+    : num_features_(num_features) {}
 
   AUTOGRAD_KWARG(BatchNorm, double, eps, 1e-5, 1e-5)
   AUTOGRAD_KWARG(BatchNorm, double, momentum, 0.1, 0.1)
@@ -296,41 +310,45 @@ public:
   Variable running_mean;
   Variable running_var;
 
-protected:
+ protected:
   uint32_t num_features_;
 };
 
 AUTOGRAD_CONTAINER_CLASS(Dropout) {
-public:
-  Dropout(double p = 0.5) : p_(p) { assert(p < 1 && p >= 0); }
+ public:
+  Dropout(double p=0.5) : p_(p) { assert(p < 1 && p >= 0); }
   variable_list forward(variable_list) override;
-
-protected:
+ protected:
   double p_;
 };
 
 AUTOGRAD_CONTAINER_CLASS(Dropout2d) {
-public:
-  Dropout2d(double p = 0.5) : p_(p) { assert(p < 1 && p >= 0); }
+ public:
+  Dropout2d(double p=0.5) : p_(p) { assert(p < 1 && p >= 0); }
   variable_list forward(variable_list) override;
-
-protected:
+ protected:
   double p_;
 };
 
-template <typename Derived> class RNNBase : public Container_CRTP<Derived> {
-public:
+template <typename Derived>
+class RNNBase : public Container_CRTP<Derived> {
+ public:
   // These must line up with the CUDNN mode codes
-  enum RNNMode : int64_t { RNN_RELU = 0, RNN_TANH = 1, LSTM = 2, GRU = 3 };
+  enum RNNMode : int64_t {
+    RNN_RELU = 0,
+    RNN_TANH = 1,
+    LSTM = 2,
+    GRU = 3
+  };
   RNNBase(uint32_t input_size, uint32_t hidden_size)
-      : input_size_(input_size), hidden_size_(hidden_size) {}
+    : input_size_(input_size), hidden_size_(hidden_size) { }
 
   AUTOGRAD_KWARG(RNNBase, RNNMode, mode, RNNMode::LSTM, RNNMode::LSTM)
   AUTOGRAD_KWARG(RNNBase, uint32_t, nlayers, 1, 1);
   AUTOGRAD_KWARG(RNNBase, bool, no_bias, false, true)
   AUTOGRAD_KWARG(RNNBase, float, dropout, 0, 0)
 
-  bool flatten_parameters(); // Flatten for cudnn
+  bool flatten_parameters();  // Flatten for cudnn
 
   variable_list forward(variable_list) override;
   void initialize_containers() override;
@@ -342,18 +360,17 @@ public:
   std::vector<Container> i2h;
   std::vector<Container> h2h;
 
-protected:
+ protected:
   uint32_t input_size_;
   uint32_t hidden_size_;
   uint32_t gate_size_;
   // This is copied from pytorch, to determine whether weights are flat for
-  // the fast CUDNN route. Otherwise, we have to use non flattened weights,
-  // which
+  // the fast CUDNN route. Otherwise, we have to use non flattened weights, which
   // are much slower.
   // https://github.com/pytorch/pytorch/blob/1848cad10802db9fa0aa066d9de195958120d863/torch/nn/modules/rnn.py#L159-L165
   // TODO Actually since we are in C++ we can probably just actually check if
   // the parameters are flat, instead of relying on data pointers and stuff.
-  std::vector<void *> data_ptrs_;
+  std::vector<void*> data_ptrs_;
   Variable flat_weight_;
   Container dropout_module;
 
@@ -371,7 +388,7 @@ protected:
 class LSTM;
 template class RNNBase<LSTM>;
 class LSTM : public RNNBase<LSTM> {
-public:
+ public:
   LSTM(uint32_t inp_size, uint32_t hid_size) : RNNBase(inp_size, hid_size) {
     mode_ = RNNBase::RNNMode::LSTM;
   }
@@ -380,7 +397,7 @@ public:
 class GRU;
 template class RNNBase<GRU>;
 class GRU : public RNNBase<GRU> {
-public:
+ public:
   GRU(uint32_t inp_size, uint32_t hid_size) : RNNBase(inp_size, hid_size) {
     mode_ = RNNBase::RNNMode::GRU;
   }
@@ -389,10 +406,10 @@ public:
 class RNN;
 template class RNNBase<RNN>;
 class RNN : public RNNBase<RNN> {
-public:
+ public:
   enum Mode { Tanh, Relu };
   RNN(uint32_t inp_size, uint32_t hid_size, Mode mode = Mode::Tanh)
-      : RNNBase(inp_size, hid_size) {
+    : RNNBase(inp_size, hid_size) {
     if (mode == Mode::Tanh) {
       mode_ = RNNBase::RNNMode::RNN_TANH;
     } else if (mode == Mode::Relu) {

--- a/include/autogradpp/containers.h
+++ b/include/autogradpp/containers.h
@@ -4,49 +4,48 @@
 
 #include "torch/csrc/autograd/variable.h"
 
-#define AUTOGRAD_CONTAINER_CLASS(Type) class Type : public autograd::Container_CRTP<Type>
+#define AUTOGRAD_CONTAINER_CLASS(Type)                                         \
+  class Type : public autograd::Container_CRTP<Type>
 
 namespace autograd {
 class ContainerImpl {
- public:
+public:
   // Only construct parameters in initialize_parameters, and
   // containers in initialize_containers. Most of the time, the containers are
   // the only thing you need to add.
   // You are guaranteed that containers are added before parameters.
-  virtual void initialize_containers() { };
-  virtual void initialize_parameters() { };
-  virtual void reset_parameters() { };
+  virtual void initialize_containers(){};
+  virtual void initialize_parameters(){};
+  virtual void reset_parameters(){};
 
   virtual variable_list forward(variable_list) = 0;
   virtual Container clone() const = 0;
 
   std::map<std::string, Variable> parameters() const;
-  Variable& param(std::string const&);
+  Variable &param(std::string const &);
 
   virtual void cuda();
   virtual void cpu();
   void train();
   void eval();
 
-  at::Type& DefaultTensor(at::ScalarType s);
+  at::Type &DefaultTensor(at::ScalarType s);
 
   std::unordered_map<std::string, Container> children_;
   std::unordered_map<std::string, Variable> params_;
   bool cuda_ = false;
   bool train_ = true;
 
-  template<class Archive>
-  void save(Archive & ar) const {
+  template <class Archive> void save(Archive &ar) const {
     auto params = parameters();
     std::size_t size = params.size();
     ar(size);
-    for (auto& p : params) {
+    for (auto &p : params) {
       ar(p.first, p.second);
     }
   }
 
-  template<class Archive>
-  void load(Archive & ar) {
+  template <class Archive> void load(Archive &ar) {
     auto params = parameters();
     std::size_t size;
     ar(size);
@@ -57,17 +56,16 @@ class ContainerImpl {
     }
   }
 
- protected:
-  Container add(Container, std::string const&);
+protected:
+  Container add(Container, std::string const &);
   // Be careful when registering Tensors that are not variables
-  Variable& add(Variable, std::string const&);
+  Variable &add(Variable, std::string const &);
 };
 
-template <class Derived>
-class Container_CRTP : public ContainerImpl {
- public:
+template <class Derived> class Container_CRTP : public ContainerImpl {
+public:
   std::shared_ptr<Derived> make() const {
-    auto ptr = std::make_shared<Derived>(*static_cast<const Derived*>(this));
+    auto ptr = std::make_shared<Derived>(*static_cast<const Derived *>(this));
     ptr->initialize_containers();
     ptr->initialize_parameters();
     ptr->reset_parameters();
@@ -75,13 +73,13 @@ class Container_CRTP : public ContainerImpl {
   }
 
   Container clone() const override {
-    auto ptr = std::make_shared<Derived>(*static_cast<const Derived*>(this));
+    auto ptr = std::make_shared<Derived>(*static_cast<const Derived *>(this));
     ptr->children_.clear();
     ptr->params_.clear();
     ptr->initialize_containers();
     ptr->initialize_parameters();
     auto newParams = ptr->parameters();
-    for (auto& param : parameters()) {
+    for (auto &param : parameters()) {
       newParams[param.first].data().copy_(param.second.data());
     }
     return ptr;
@@ -92,38 +90,27 @@ template <class Derived>
 class ContainerListImpl : public Container_CRTP<Derived> {
   // Lets you use a container like a vector without making a new class,
   // just for simple implementations
- public:
+public:
   virtual variable_list forward(variable_list) override {
-    throw std::runtime_error(
-        "ContainerList has no forward, maybe you"
-        " wanted to subclass and override this function?");
+    throw std::runtime_error("ContainerList has no forward, maybe you"
+                             " wanted to subclass and override this function?");
   }
 
-  Container add(Container m) {
-    return append(m).children_.back();
-  }
+  Container add(Container m) { return append(m).children_.back(); }
 
-  ContainerListImpl<Derived>& append(Container m) {
+  ContainerListImpl<Derived> &append(Container m) {
     children_.push_back(m);
     ContainerImpl::add(children_.back(), std::to_string(size() - 1));
     return *this;
   }
 
-  Container& operator[](int index) {
-    return children_[index];
-  }
+  Container &operator[](int index) { return children_[index]; }
 
-  int size() {
-    return children_.size();
-  }
+  int size() { return children_.size(); }
 
-  auto begin() {
-    return children_.begin();
-  }
+  auto begin() { return children_.begin(); }
 
-  auto end() {
-    return children_.end();
-  }
+  auto end() { return children_.end(); }
 
   std::vector<Container> children_;
 };
@@ -132,9 +119,9 @@ class ContainerList : public ContainerListImpl<ContainerList> {};
 
 class Sequential : public ContainerListImpl<Sequential> {
   // Mimics nn.Sequential from pytorch.
- public:
+public:
   variable_list forward(variable_list input) override {
-    for (auto& container : children_) {
+    for (auto &container : children_) {
       input = container->forward(input);
     }
     return input;
@@ -144,7 +131,7 @@ class Sequential : public ContainerListImpl<Sequential> {
     return append(m, name).children_.back();
   }
 
-  Sequential& append(Container m, std::string name = "") {
+  Sequential &append(Container m, std::string name = "") {
     if (name == "") {
       name = std::to_string(size());
     }
@@ -157,131 +144,130 @@ class Sequential : public ContainerListImpl<Sequential> {
 AUTOGRAD_CONTAINER_CLASS(SimpleContainer) {
   // Lets you use a container without making a new class,
   // for experimental implementations
- public:
+public:
   virtual variable_list forward(variable_list) override {
     throw std::runtime_error("SimpleContainer has no forward, maybe you"
-        " wanted to subclass and override this function?");
+                             " wanted to subclass and override this function?");
   }
   using ContainerImpl::add;
-
 };
 
 AUTOGRAD_CONTAINER_CLASS(Linear) {
- public:
-   Linear(uint32_t nin, uint32_t nout)
-     : nin(nin), nout(nout) { }
+public:
+  Linear(uint32_t nin, uint32_t nout) : nin(nin), nout(nout) {}
 
-   variable_list forward(variable_list) override;
-   void reset_parameters() override;
-   void initialize_parameters() override;
-   AUTOGRAD_KWARG(Linear, bool, no_bias, false, true);
+  variable_list forward(variable_list) override;
+  void reset_parameters() override;
+  void initialize_parameters() override;
+  AUTOGRAD_KWARG(Linear, bool, no_bias, false, true);
 
   Variable weight, bias;
   uint32_t nin, nout;
 };
 
 AUTOGRAD_CONTAINER_CLASS(Embedding) {
- public:
-   Embedding(uint32_t num_embeddings, uint32_t embedding_dim)
-     : num_embeddings(num_embeddings), embedding_dim(embedding_dim) { }
+public:
+  Embedding(uint32_t num_embeddings, uint32_t embedding_dim)
+      : num_embeddings(num_embeddings), embedding_dim(embedding_dim) {}
 
-   variable_list forward(variable_list) override;
-   void reset_parameters() override;
-   void initialize_parameters() override;
+  variable_list forward(variable_list) override;
+  void reset_parameters() override;
+  void initialize_parameters() override;
 
   Variable weight;
   uint32_t num_embeddings, embedding_dim;
 };
 
 AUTOGRAD_CONTAINER_CLASS(Conv) {
- private:
+private:
   Conv(uint32_t Nd, uint32_t in_chan, uint32_t out_chan)
-    : Nd_(Nd),
-      in_channels_(in_chan),
-      out_channels_(out_chan),
-      stride_(makeTup(1, 1)),
-      padding_(makeTup(0)),
-      dilation_(makeTup(1, 1)),
-      dilated_(false),
-      output_padding_(makeTup(0))
-      { }
+      : Nd_(Nd), in_channels_(in_chan), out_channels_(out_chan),
+        stride_(makeTup(1, 1)), padding_(makeTup(0)), dilation_(makeTup(1, 1)),
+        dilated_(false), output_padding_(makeTup(0)) {}
 
- public:
+public:
   Conv(uint32_t Nd, uint32_t in_chan, uint32_t out_chan, int ks)
-    : Conv(Nd, in_chan, out_chan) {
-      ks_ = makeTup(ks, 1);
-    }
+      : Conv(Nd, in_chan, out_chan) {
+    ks_ = makeTup(ks, 1);
+  }
 
   Conv(uint32_t Nd, uint32_t in_chan, uint32_t out_chan, IntVec ks)
-    : Conv(Nd, in_chan, out_chan) {
-      ks_ = makeTup(ks);
-    }
+      : Conv(Nd, in_chan, out_chan) {
+    ks_ = makeTup(ks);
+  }
 
   void reset_parameters() override;
   variable_list forward(variable_list) override;
   void initialize_parameters() override;
 
-  template <typename T>
-  Conv& stride(T s) { stride_ = makeTup(s, 1); return *this; }
-  template <typename T>
-  Conv& padding(T s) { padding_ = makeTup(s); return *this; }
-  template <typename T>
-  Conv& dilation(T s) { dilation_ = makeTup(s, 1); return *this; }
-  template <typename T>
-  Conv& output_padding(T s) { output_padding_ = makeTup(s); return *this; }
+  template <typename T> Conv &stride(T s) {
+    stride_ = makeTup(s, 1);
+    return *this;
+  }
+  template <typename T> Conv &padding(T s) {
+    padding_ = makeTup(s);
+    return *this;
+  }
+  template <typename T> Conv &dilation(T s) {
+    dilation_ = makeTup(s, 1);
+    return *this;
+  }
+  template <typename T> Conv &output_padding(T s) {
+    output_padding_ = makeTup(s);
+    return *this;
+  }
 
   AUTOGRAD_KWARG(Conv, bool, transposed, false, true)
   AUTOGRAD_KWARG(Conv, bool, no_bias, false, true)
   AUTOGRAD_KWARG(Conv, int, groups, 1, 1)
 
-   Variable weight, bias;
-   uint32_t Nd_;
-   uint32_t in_channels_;
-   uint32_t out_channels_;
-   IntVec ks_;
-   IntVec stride_;
-   IntVec padding_;
-   IntVec dilation_;
-   bool dilated_;
-   IntVec output_padding_;
-  protected:
-   IntVec makeTup(int x, int def=0) {
-     IntVec ret;
-     if (Nd_ == 1) {
-       ret.push_back(x);
-       ret.push_back(def);
-     } else {
-       for (auto i = 0U; i < Nd_; i++) ret.push_back(x);
-     }
-     return ret;
-   }
-   IntVec makeTup(IntVec x) {
-     return x;
-   }
+  Variable weight, bias;
+  uint32_t Nd_;
+  uint32_t in_channels_;
+  uint32_t out_channels_;
+  IntVec ks_;
+  IntVec stride_;
+  IntVec padding_;
+  IntVec dilation_;
+  bool dilated_;
+  IntVec output_padding_;
+
+protected:
+  IntVec makeTup(int x, int def = 0) {
+    IntVec ret;
+    if (Nd_ == 1) {
+      ret.push_back(x);
+      ret.push_back(def);
+    } else {
+      for (auto i = 0U; i < Nd_; i++)
+        ret.push_back(x);
+    }
+    return ret;
+  }
+  IntVec makeTup(IntVec x) { return x; }
 };
 
 class Conv1d : public Conv {
- public:
-  Conv1d(uint32_t i, uint32_t o, int ks) : Conv(1, i, o, ks) { }
-  Conv1d(uint32_t i, uint32_t o, IntVec ks) : Conv(1, i, o, ks) { }
+public:
+  Conv1d(uint32_t i, uint32_t o, int ks) : Conv(1, i, o, ks) {}
+  Conv1d(uint32_t i, uint32_t o, IntVec ks) : Conv(1, i, o, ks) {}
 };
 
 class Conv2d : public Conv {
- public:
-  Conv2d(uint32_t i, uint32_t o, int ks) : Conv(2, i, o, ks) { }
-  Conv2d(uint32_t i, uint32_t o, IntVec ks) : Conv(2, i, o, ks) { }
+public:
+  Conv2d(uint32_t i, uint32_t o, int ks) : Conv(2, i, o, ks) {}
+  Conv2d(uint32_t i, uint32_t o, IntVec ks) : Conv(2, i, o, ks) {}
 };
 
 class Conv3d : public Conv {
- public:
-  Conv3d(uint32_t i, uint32_t o, int ks) : Conv(3, i, o, ks) { }
-  Conv3d(uint32_t i, uint32_t o, IntVec ks) : Conv(3, i, o, ks) { }
+public:
+  Conv3d(uint32_t i, uint32_t o, int ks) : Conv(3, i, o, ks) {}
+  Conv3d(uint32_t i, uint32_t o, IntVec ks) : Conv(3, i, o, ks) {}
 };
 
 AUTOGRAD_CONTAINER_CLASS(BatchNorm) {
- public:
-  BatchNorm(uint32_t num_features)
-    : num_features_(num_features) {}
+public:
+  BatchNorm(uint32_t num_features) : num_features_(num_features) {}
 
   AUTOGRAD_KWARG(BatchNorm, double, eps, 1e-5, 1e-5)
   AUTOGRAD_KWARG(BatchNorm, double, momentum, 0.1, 0.1)
@@ -297,45 +283,41 @@ AUTOGRAD_CONTAINER_CLASS(BatchNorm) {
   Variable running_mean;
   Variable running_var;
 
- protected:
+protected:
   uint32_t num_features_;
 };
 
 AUTOGRAD_CONTAINER_CLASS(Dropout) {
- public:
-  Dropout(double p=0.5) : p_(p) { assert(p < 1 && p >= 0); }
+public:
+  Dropout(double p = 0.5) : p_(p) { assert(p < 1 && p >= 0); }
   variable_list forward(variable_list) override;
- protected:
+
+protected:
   double p_;
 };
 
 AUTOGRAD_CONTAINER_CLASS(Dropout2d) {
- public:
-  Dropout2d(double p=0.5) : p_(p) { assert(p < 1 && p >= 0); }
+public:
+  Dropout2d(double p = 0.5) : p_(p) { assert(p < 1 && p >= 0); }
   variable_list forward(variable_list) override;
- protected:
+
+protected:
   double p_;
 };
 
-template <typename Derived>
-class RNNBase : public Container_CRTP<Derived> {
- public:
+template <typename Derived> class RNNBase : public Container_CRTP<Derived> {
+public:
   // These must line up with the CUDNN mode codes
-  enum RNNMode : int64_t {
-    RNN_RELU = 0,
-    RNN_TANH = 1,
-    LSTM = 2,
-    GRU = 3
-  };
+  enum RNNMode : int64_t { RNN_RELU = 0, RNN_TANH = 1, LSTM = 2, GRU = 3 };
   RNNBase(uint32_t input_size, uint32_t hidden_size)
-    : input_size_(input_size), hidden_size_(hidden_size) { }
+      : input_size_(input_size), hidden_size_(hidden_size) {}
 
   AUTOGRAD_KWARG(RNNBase, RNNMode, mode, RNNMode::LSTM, RNNMode::LSTM)
   AUTOGRAD_KWARG(RNNBase, uint32_t, nlayers, 1, 1);
   AUTOGRAD_KWARG(RNNBase, bool, no_bias, false, true)
   AUTOGRAD_KWARG(RNNBase, float, dropout, 0, 0)
 
-  bool flatten_parameters();  // Flatten for cudnn
+  bool flatten_parameters(); // Flatten for cudnn
 
   variable_list forward(variable_list) override;
   void initialize_containers() override;
@@ -347,17 +329,18 @@ class RNNBase : public Container_CRTP<Derived> {
   std::vector<Container> i2h;
   std::vector<Container> h2h;
 
- protected:
+protected:
   uint32_t input_size_;
   uint32_t hidden_size_;
   uint32_t gate_size_;
   // This is copied from pytorch, to determine whether weights are flat for
-  // the fast CUDNN route. Otherwise, we have to use non flattened weights, which
+  // the fast CUDNN route. Otherwise, we have to use non flattened weights,
+  // which
   // are much slower.
   // https://github.com/pytorch/pytorch/blob/1848cad10802db9fa0aa066d9de195958120d863/torch/nn/modules/rnn.py#L159-L165
   // TODO Actually since we are in C++ we can probably just actually check if
   // the parameters are flat, instead of relying on data pointers and stuff.
-  std::vector<void*> data_ptrs_;
+  std::vector<void *> data_ptrs_;
   Variable flat_weight_;
   Container dropout_module;
 
@@ -375,7 +358,7 @@ class RNNBase : public Container_CRTP<Derived> {
 class LSTM;
 template class RNNBase<LSTM>;
 class LSTM : public RNNBase<LSTM> {
- public:
+public:
   LSTM(uint32_t inp_size, uint32_t hid_size) : RNNBase(inp_size, hid_size) {
     mode_ = RNNBase::RNNMode::LSTM;
   }
@@ -384,7 +367,7 @@ class LSTM : public RNNBase<LSTM> {
 class GRU;
 template class RNNBase<GRU>;
 class GRU : public RNNBase<GRU> {
- public:
+public:
   GRU(uint32_t inp_size, uint32_t hid_size) : RNNBase(inp_size, hid_size) {
     mode_ = RNNBase::RNNMode::GRU;
   }
@@ -393,10 +376,10 @@ class GRU : public RNNBase<GRU> {
 class RNN;
 template class RNNBase<RNN>;
 class RNN : public RNNBase<RNN> {
- public:
+public:
   enum Mode { Tanh, Relu };
   RNN(uint32_t inp_size, uint32_t hid_size, Mode mode = Mode::Tanh)
-    : RNNBase(inp_size, hid_size) {
+      : RNNBase(inp_size, hid_size) {
     if (mode == Mode::Tanh) {
       mode_ = RNNBase::RNNMode::RNN_TANH;
     } else if (mode == Mode::Relu) {

--- a/include/autogradpp/containers.h
+++ b/include/autogradpp/containers.h
@@ -152,6 +152,19 @@ public:
   using ContainerImpl::add;
 };
 
+AUTOGRAD_CONTAINER_CLASS(Functional) {
+  // Lets you create a container from a function, designed for use in
+  // Sequential.
+public:
+  Functional(std::function<variable_list(variable_list)> fun) : fun_(fun){};
+  Functional(std::function<Variable(Variable)> fun)
+      : fun_([&](variable_list input) { return variable_list({fun(input[0])}); }){};
+
+  variable_list forward(variable_list input) override { return fun_(input); };
+
+  std::function<variable_list(variable_list)> fun_;
+};
+
 AUTOGRAD_CONTAINER_CLASS(Linear) {
 public:
   Linear(uint32_t nin, uint32_t nout) : nin(nin), nout(nout) {}

--- a/src/containers.cpp
+++ b/src/containers.cpp
@@ -4,10 +4,10 @@ namespace autograd {
 std::map<std::string, Variable> ContainerImpl::parameters() const {
   std::map<std::string, Variable> ret;
   for (auto pair : children_) {
-    auto& name = pair.first;
-    auto& child = pair.second;
-    for (auto& p : child->parameters()) {
-      ret[name + "/" + p.first] = p.second;
+    auto &name = pair.first;
+    auto &child = pair.second;
+    for (auto &p : child->parameters()) {
+      ret[name + "." + p.first] = p.second;
     }
   }
   for (auto pair : params_) {
@@ -16,8 +16,27 @@ std::map<std::string, Variable> ContainerImpl::parameters() const {
   return ret;
 }
 
-Variable& ContainerImpl::param(std::string const& name) {
-  auto it = params_.find(name);
+Variable &ContainerImpl::param(std::string const &name) {
+  ContainerImpl& container = *this;
+  auto begin = 0;
+  while (true) {
+    auto dot_pos = name.find('.', begin);
+    if (dot_pos == name.size()) {
+      break;
+    }
+
+    auto child_name = name.substr(begin, dot_pos - begin);
+    auto it = container.children_.find(child_name);
+    if (it == container.children_.end()) {
+      throw std::runtime_error("No such child: " + child_name);
+    }
+
+    container = *(it->second);
+    begin = dot_pos + 1; // Skip the dot
+  }
+
+  auto param_name = name.substr(begin);
+  auto it = container.params_.find(param_name);
   if (it == params_.end()) {
     throw std::runtime_error("No such param: " + name);
   }
@@ -25,7 +44,7 @@ Variable& ContainerImpl::param(std::string const& name) {
 }
 
 void ContainerImpl::cuda() {
-  for (auto& pair : children_) {
+  for (auto &pair : children_) {
     pair.second->cuda();
   }
   cuda_ = true;
@@ -38,7 +57,7 @@ void ContainerImpl::cuda() {
 };
 
 void ContainerImpl::cpu() {
-  for (auto& pair : children_) {
+  for (auto &pair : children_) {
     pair.second->cpu();
   }
   cuda_ = false;
@@ -51,38 +70,50 @@ void ContainerImpl::cpu() {
 };
 
 void ContainerImpl::train() {
-  for (auto& pair : children_) {
+  for (auto &pair : children_) {
     pair.second->train();
   }
   train_ = true;
 }
 
 void ContainerImpl::eval() {
-  for (auto& pair : children_) {
+  for (auto &pair : children_) {
     pair.second->eval();
   }
   train_ = false;
 }
 
-Container ContainerImpl::add(Container m, std::string const& name) {
+Container ContainerImpl::add(Container m, std::string const &name) {
   if (this->children_.find(name) != this->children_.end()) {
     throw std::runtime_error("Trying to add container that already exists");
+  }
+  if (std::find(name.begin(), name.end(), '.') != name.end()) {
+    // We can't allow containers with dots in their names, as that would make
+    // their parameters not findable with parameters().
+    throw std::runtime_error("Trying to add parameter with a '.' in its name");
   }
   this->children_[name] = std::move(m);
   return this->children_[name];
 }
 
-Variable& ContainerImpl::add(Variable v, std::string const& name) {
+Variable &ContainerImpl::add(Variable v, std::string const &name) {
   if (this->params_.find(name) != this->params_.end()) {
     throw std::runtime_error("Trying to add parameter that already exists");
+  }
+  if (std::find(name.begin(), name.end(), '.') != name.end()) {
+    // We can't allow parameters with dots in their names, as that would make
+    // them not findable with parameters().
+    throw std::runtime_error("Trying to add parameter with a '.' in its name");
   }
   this->params_[name] = v;
   return this->params_[name];
 }
 
-at::Type& ContainerImpl::DefaultTensor(at::ScalarType s) {
-  if (cuda_) return at::CUDA(s);
-  else return at::CPU(s);
+at::Type &ContainerImpl::DefaultTensor(at::ScalarType s) {
+  if (cuda_)
+    return at::CUDA(s);
+  else
+    return at::CPU(s);
 }
 
 variable_list Linear::forward(variable_list input) {
@@ -102,15 +133,17 @@ variable_list Linear::forward(variable_list input) {
 
 void Linear::reset_parameters() {
   auto stdv = 1.0 / std::sqrt(weight.size(1));
-  for (auto& p : parameters()) {
+  for (auto &p : parameters()) {
     p.second.data().uniform_(-stdv, stdv);
   }
 }
 
 void Linear::initialize_parameters() {
-  weight = this->add(Var(DefaultTensor(at::kFloat).tensor({nout, nin}), true), "weight");
+  weight = this->add(Var(DefaultTensor(at::kFloat).tensor({nout, nin}), true),
+                     "weight");
   if (!no_bias_) {
-    bias = this->add(Var(DefaultTensor(at::kFloat).tensor({nout}), true), "bias");
+    bias =
+        this->add(Var(DefaultTensor(at::kFloat).tensor({nout}), true), "bias");
   }
 }
 
@@ -120,20 +153,24 @@ variable_list Embedding::forward(variable_list input) {
 }
 
 void Embedding::reset_parameters() {
-  for (auto& p : parameters()) {
+  for (auto &p : parameters()) {
     p.second.data().normal_(0, 1);
   }
 }
 
 void Embedding::initialize_parameters() {
-  weight = this->add(Var(DefaultTensor(at::kFloat).tensor({num_embeddings, embedding_dim}), true), "weight");
+  weight = this->add(
+      Var(DefaultTensor(at::kFloat).tensor({num_embeddings, embedding_dim}),
+          true),
+      "weight");
 }
 
 void Conv::initialize_parameters() {
   if (!transposed_) {
     for (auto pad : output_padding_) {
       if (pad != 0) {
-        throw std::runtime_error("Only transposed convolutions support output padding!");
+        throw std::runtime_error(
+            "Only transposed convolutions support output padding!");
       }
     }
   }
@@ -147,9 +184,11 @@ void Conv::initialize_parameters() {
     wsize.push_back(in_channels_ / groups_);
   }
   wsize.insert(wsize.end(), ks_.begin(), ks_.end());
-  weight = this->add(Var(DefaultTensor(at::kFloat).tensor(wsize), true), "weight");
+  weight =
+      this->add(Var(DefaultTensor(at::kFloat).tensor(wsize), true), "weight");
   if (!no_bias_) {
-    bias = this->add(Var(DefaultTensor(at::kFloat).tensor({out_channels_}), true), "bias");
+    bias = this->add(
+        Var(DefaultTensor(at::kFloat).tensor({out_channels_}), true), "bias");
   } else {
     assert(!bias.defined());
   }
@@ -157,9 +196,10 @@ void Conv::initialize_parameters() {
 
 void Conv::reset_parameters() {
   auto n = in_channels_;
-  for (auto k : ks_) n *= k;
+  for (auto k : ks_)
+    n *= k;
   auto stdv = 1.0 / std::sqrt(n);
-  for (auto& p : parameters()) {
+  for (auto &p : parameters()) {
     p.second.data().uniform_(-stdv, stdv);
   }
 }
@@ -168,7 +208,7 @@ variable_list Conv::forward(variable_list input) {
   auto x = input[0];
   if (Nd_ == 1) {
     assert(x.ndimension() == 3);
-    x = x.unsqueeze(-1);  // TODO: Use conv1d once available
+    x = x.unsqueeze(-1); // TODO: Use conv1d once available
   } else if (Nd_ == 2) {
     assert(x.ndimension() == 4);
   } else if (Nd_ == 3) {
@@ -180,13 +220,15 @@ variable_list Conv::forward(variable_list input) {
   Variable out;
   if (Nd_ == 1 || Nd_ == 2) {
     if (transposed_) {
-      out = at::conv_transpose2d(x, weight, bias, stride_, padding_, output_padding_, 1, dilation_);
+      out = at::conv_transpose2d(x, weight, bias, stride_, padding_,
+                                 output_padding_, 1, dilation_);
     } else {
       out = at::conv2d(x, weight, bias, stride_, padding_, dilation_);
     }
   } else if (Nd_ == 3) {
     if (transposed_) {
-      out = at::conv_transpose3d(x, weight, bias, stride_, padding_, output_padding_, 1, dilation_);
+      out = at::conv_transpose3d(x, weight, bias, stride_, padding_,
+                                 output_padding_, 1, dilation_);
     } else {
       out = at::conv3d(x, weight, bias, stride_, padding_, dilation_);
     }
@@ -197,8 +239,10 @@ variable_list Conv::forward(variable_list input) {
 
 void BatchNorm::initialize_parameters() {
   if (affine_) {
-    weight = this->add(Var(DefaultTensor(at::kFloat).tensor(num_features_), true), "weight");
-    bias = this->add(Var(DefaultTensor(at::kFloat).tensor(num_features_), true), "bias");
+    weight = this->add(
+        Var(DefaultTensor(at::kFloat).tensor(num_features_), true), "weight");
+    bias = this->add(Var(DefaultTensor(at::kFloat).tensor(num_features_), true),
+                     "bias");
   }
 
   if (stateful_) {
@@ -220,9 +264,9 @@ void BatchNorm::reset_parameters() {
 }
 
 variable_list BatchNorm::forward(variable_list inputs) {
-  auto& input = inputs[0];
-  auto& running_mean = (stateful_ ? this->running_mean : inputs[1]);
-  auto& running_var = (stateful_ ? this->running_var : inputs[2]);
+  auto &input = inputs[0];
+  auto &running_mean = (stateful_ ? this->running_mean : inputs[1]);
+  auto &running_var = (stateful_ ? this->running_var : inputs[2]);
 
   if (train_) {
     const auto num_channels = input.dim() > 1 ? input.size(1) : 1;
@@ -232,18 +276,13 @@ variable_list BatchNorm::forward(variable_list inputs) {
     }
   }
 
-  auto output = at::batch_norm(
-      input,
-      weight, bias,
-      running_mean, running_var,
-      train_, momentum_, eps_,
-      hasCudnn());
+  auto output = at::batch_norm(input, weight, bias, running_mean, running_var,
+                               train_, momentum_, eps_, hasCudnn());
 
   return variable_list({output});
 }
 
-template <typename Derived>
-void RNNBase<Derived>::initialize_containers() {
+template <typename Derived> void RNNBase<Derived>::initialize_containers() {
   auto gate_size = hidden_size_;
   if (mode_ == RNNMode::LSTM) {
     gate_size *= 4;
@@ -253,17 +292,26 @@ void RNNBase<Derived>::initialize_containers() {
 
   for (auto i = 0U; i < nlayers_; i++) {
     auto input_size = (i == 0) ? input_size_ : hidden_size_;
-    i2h.push_back(this->add(Linear(input_size, gate_size).no_bias(no_bias_).make(), "i2h_" + std::to_string(i)));
-    h2h.push_back(this->add(Linear(hidden_size_, gate_size).no_bias(no_bias_).make(), "h2h_" + std::to_string(i)));
+    // We get parameters names of the form [ih]h_l<layer num>.{weight}|{bias}
+    // whereas pytorch has {weight}|{bias}_[ih]h_l<layer num>
+    // Having the right parameter names would require to change the architecture
+    // and honestly the pytorch names are not really logical (their order is the
+    // inverse of the inclusion ordering)
+    i2h.push_back(
+        this->add(Linear(input_size, gate_size).no_bias(no_bias_).make(),
+                  "ih_l" + std::to_string(i)));
+    h2h.push_back(
+        this->add(Linear(hidden_size_, gate_size).no_bias(no_bias_).make(),
+                  "hh_l" + std::to_string(i)));
   }
-  if (dropout_ > 0) dropout_module = Dropout(dropout_).make();
+  if (dropout_ > 0)
+    dropout_module = Dropout(dropout_).make();
   this->flatten_parameters();
 }
 
-template <typename Derived>
-void RNNBase<Derived>::reset_parameters() {
+template <typename Derived> void RNNBase<Derived>::reset_parameters() {
   auto stdv = 1.0 / std::sqrt(hidden_size_);
-  for (auto& p : this->parameters()) {
+  for (auto &p : this->parameters()) {
     p.second.data().uniform_(-stdv, stdv);
   }
 }
@@ -271,9 +319,9 @@ void RNNBase<Derived>::reset_parameters() {
 template <typename Derived>
 variable_list RNNBase<Derived>::GRU_cell_forward(variable_list inputs, int i) {
   auto x = inputs[0];
-  auto hx = inputs[1].defined()
-    ? inputs[1]
-    : Var(this->DefaultTensor(at::kFloat).zeros({x.size(0), hidden_size_}));
+  auto hx = inputs[1].defined() ? inputs[1]
+                                : Var(this->DefaultTensor(at::kFloat)
+                                          .zeros({x.size(0), hidden_size_}));
 
   auto gi = i2h[i]->forward({x})[0];
   auto gh = h2h[i]->forward({hx})[0];
@@ -289,22 +337,24 @@ variable_list RNNBase<Derived>::GRU_cell_forward(variable_list inputs, int i) {
 }
 
 template <typename Derived>
-variable_list RNNBase<Derived>::RNN_TANH_cell_forward(variable_list inputs, int i) {
+variable_list RNNBase<Derived>::RNN_TANH_cell_forward(variable_list inputs,
+                                                      int i) {
   auto x = inputs[0];
-  auto hx = inputs[1].defined()
-    ? inputs[1]
-    : Var(this->DefaultTensor(at::kFloat).zeros({x.size(0), hidden_size_}));
+  auto hx = inputs[1].defined() ? inputs[1]
+                                : Var(this->DefaultTensor(at::kFloat)
+                                          .zeros({x.size(0), hidden_size_}));
 
   auto h = (i2h[i]->forward({x})[0] + h2h[i]->forward({hx})[0]).tanh();
   return variable_list({h});
 }
 
 template <typename Derived>
-variable_list RNNBase<Derived>::RNN_RELU_cell_forward(variable_list inputs, int i) {
+variable_list RNNBase<Derived>::RNN_RELU_cell_forward(variable_list inputs,
+                                                      int i) {
   auto x = inputs[0];
-  auto hx = inputs[1].defined()
-    ? inputs[1]
-    : Var(this->DefaultTensor(at::kFloat).zeros({x.size(0), hidden_size_}));
+  auto hx = inputs[1].defined() ? inputs[1]
+                                : Var(this->DefaultTensor(at::kFloat)
+                                          .zeros({x.size(0), hidden_size_}));
 
   auto h = (i2h[i]->forward({x})[0] + h2h[i]->forward({hx})[0]).clamp_min(0);
   return variable_list({h});
@@ -314,8 +364,9 @@ template <typename Derived>
 variable_list RNNBase<Derived>::LSTM_cell_forward(variable_list inputs, int i) {
   auto x = inputs[0];
   auto hid = inputs[1].defined()
-    ? inputs[1]
-    : Var(this->DefaultTensor(at::kFloat).zeros({2, x.size(0), hidden_size_}));
+                 ? inputs[1]
+                 : Var(this->DefaultTensor(at::kFloat)
+                           .zeros({2, x.size(0), hidden_size_}));
   auto hx = hid[0];
   auto cx = hid[1];
 
@@ -330,16 +381,21 @@ variable_list RNNBase<Derived>::LSTM_cell_forward(variable_list inputs, int i) {
   auto cy = (forget_gate * cx) + (in_gate * cell_gate);
   auto hy = out_gate * cy.tanh();
 
-  return variable_list({at::stack({hy, cy}, 0)}); 
+  return variable_list({at::stack({hy, cy}, 0)});
 }
 
 template <typename Derived>
 variable_list RNNBase<Derived>::cell_forward(variable_list inputs, int i) {
-  if (mode_ == RNNMode::LSTM) return LSTM_cell_forward(inputs, i);
-  else if (mode_ == RNNMode::GRU) return GRU_cell_forward(inputs, i);
-  else if (mode_ == RNNMode::RNN_TANH) return RNN_TANH_cell_forward(inputs, i);
-  else if (mode_ == RNNMode::RNN_RELU) return RNN_RELU_cell_forward(inputs, i);
-  else throw std::runtime_error("No such RNN mode");
+  if (mode_ == RNNMode::LSTM)
+    return LSTM_cell_forward(inputs, i);
+  else if (mode_ == RNNMode::GRU)
+    return GRU_cell_forward(inputs, i);
+  else if (mode_ == RNNMode::RNN_TANH)
+    return RNN_TANH_cell_forward(inputs, i);
+  else if (mode_ == RNNMode::RNN_RELU)
+    return RNN_RELU_cell_forward(inputs, i);
+  else
+    throw std::runtime_error("No such RNN mode");
 }
 
 template <typename Derived>
@@ -348,13 +404,13 @@ variable_list RNNBase<Derived>::autograd_forward(variable_list inputs) {
 
   std::vector<Tensor> hidden;
   for (size_t i = 0; i < nlayers_; i++) {
-    hidden.push_back(inputs[1].defined() 
-        ? inputs[1][i] 
-        : tag::Variable());
+    hidden.push_back(inputs[1].defined() ? inputs[1][i] : tag::Variable());
   }
 
-  auto output = Var(this->DefaultTensor(at::kFloat).zeros({inp.size(0), inp.size(1), hidden_size_}), false);
-  for (auto t = 0U; t < inp.size(0); t++ ) {
+  auto output = Var(this->DefaultTensor(at::kFloat)
+                        .zeros({inp.size(0), inp.size(1), hidden_size_}),
+                    false);
+  for (auto t = 0U; t < inp.size(0); t++) {
     auto x = inp.select(0, t);
     for (size_t i = 0; i < nlayers_; i++) {
       auto layer_output = cell_forward({x, hidden[i]}, i);
@@ -376,21 +432,22 @@ variable_list RNNBase<Derived>::autograd_forward(variable_list inputs) {
   return variable_list({output, hidout});
 }
 
-template <typename Derived>
-bool RNNBase<Derived>::flatten_parameters() {
+template <typename Derived> bool RNNBase<Derived>::flatten_parameters() {
   data_ptrs_.clear();
   auto anyParam = i2h[0]->params_.begin()->second;
   if (!anyParam.is_cuda() || !at::cudnn_is_acceptable(anyParam)) {
     return false;
   }
-  std::unordered_set<void*> unique_data_ptrs;
+  std::unordered_set<void *> unique_data_ptrs;
   auto params = this->parameters();
-  for (auto& p : params) {
+  for (auto &p : params) {
     unique_data_ptrs.insert(p.second.data().data_ptr());
   }
   // TODO PyTorch says:
-  // If any parameters alias, we fall back to the slower, copying code path. This is
-  // a sufficient check, because overlapping parameter buffers that don't completely
+  // If any parameters alias, we fall back to the slower, copying code path.
+  // This is
+  // a sufficient check, because overlapping parameter buffers that don't
+  // completely
   // alias would break the assumptions of the uniqueness check in
   // Module.named_parameters().
   // But I'm not sure if this is the case for us
@@ -412,16 +469,11 @@ bool RNNBase<Derived>::flatten_parameters() {
   {
     no_grad_guard guard;
     flat_weight_ = at::_cudnn_rnn_flatten_weight(
-      weight_list,
-      weight_stride0,
-      input_size_,
-      mode_,
-      hidden_size_,
-      nlayers_,
-      false,
-      false); // batch_first and bidirectional, unsupported
+        weight_list, weight_stride0, input_size_, mode_, hidden_size_, nlayers_,
+        false,
+        false); // batch_first and bidirectional, unsupported
   }
-  for (auto& p : params) {
+  for (auto &p : params) {
     data_ptrs_.emplace_back(p.second.data().data_ptr());
   }
   return true;
@@ -453,40 +505,34 @@ variable_list RNNBase<Derived>::CUDNN_forward(variable_list inputs) {
   }
   auto dropout_state = x.type().tensor();
 
-  std::vector<void*> weight_data_ptrs;
+  std::vector<void *> weight_data_ptrs;
   auto params = this->parameters();
-  for (auto& p : params) {
+  for (auto &p : params) {
     weight_data_ptrs.emplace_back(p.second.data().data_ptr());
   }
   if (weight_data_ptrs != data_ptrs_) {
     std::cerr << "Parameters are unflattened! Code path might be super slow. "
-      "Please call flatten_parameters() when you muck around with storages!"
-      << std::endl;
+                 "Please call flatten_parameters() when you muck around with "
+                 "storages!"
+              << std::endl;
     flat_weight_ = Variable();
   }
 
   // tup = std::tuple of output, hy, cy, reserve, new_weight_buf
   auto tup = _cudnn_rnn(
-      x,
-      weight_list,
-      weight_stride0,
-      flat_weight_,
-      hx,
-      cx,
-      mode_,
-      hidden_size_,
+      x, weight_list, weight_stride0, flat_weight_, hx, cx, mode_, hidden_size_,
       nlayers_,
       false, // batch first
-      0, // TODO waiting on dropout state descriptor in C++ pytorch
+      0,     // TODO waiting on dropout state descriptor in C++ pytorch
       this->train_,
-      false, // bidirectional
-      {}, // packing not supported
+      false,        // bidirectional
+      {},           // packing not supported
       dropout_state // TODO waiting on dropout state descriptor in C++ pytorch
       );
 
   Variable hidout = mode_ == RNNMode::LSTM
-    ? at::stack({std::get<1>(tup), std::get<2>(tup)}, 0)
-    : std::get<1>(tup);
+                        ? at::stack({std::get<1>(tup), std::get<2>(tup)}, 0)
+                        : std::get<1>(tup);
   Variable output = std::get<0>(tup);
   return variable_list({output, hidout});
 }
@@ -503,41 +549,45 @@ variable_list RNNBase<Derived>::forward(variable_list inputs) {
 
   // Dropout descriptors aren't in C++ in PyTorch yet...
   auto output = at::cudnn_is_acceptable(inp[0]) && dropout_ == 0
-    ? CUDNN_forward(inp)
-    : autograd_forward(inp);
+                    ? CUDNN_forward(inp)
+                    : autograd_forward(inp);
 
   return output;
 }
 
-template <typename Derived>
-void RNNBase<Derived>::cuda() {
+template <typename Derived> void RNNBase<Derived>::cuda() {
   Container_CRTP<Derived>::cuda();
   flatten_parameters();
 }
 
-template <typename Derived>
-void RNNBase<Derived>::cpu() {
+template <typename Derived> void RNNBase<Derived>::cpu() {
   Container_CRTP<Derived>::cpu();
   flatten_parameters();
 }
 
 variable_list Dropout::forward(variable_list inputs) {
-  if (p_ == 0 || !this->train_) return inputs;
+  if (p_ == 0 || !this->train_)
+    return inputs;
   variable_list lst;
   for (auto x : inputs) {
     auto noise = x.data().type().tensor(x.sizes());
-    noise = (noise.uniform_(0, 1) > p_).toType(x.type().scalarType()).mul_(1. / (1 - p_));
+    noise = (noise.uniform_(0, 1) > p_)
+                .toType(x.type().scalarType())
+                .mul_(1. / (1 - p_));
     lst.push_back(x * Var(noise));
   }
   return lst;
 }
 
 variable_list Dropout2d::forward(variable_list inputs) {
-  if (p_ == 0 || !this->train_) return inputs;
+  if (p_ == 0 || !this->train_)
+    return inputs;
   variable_list lst;
   for (auto x : inputs) {
     auto noise = x.data().type().tensor({x.size(0), x.size(1), 1, 1});
-    noise = (noise.uniform_(0, 1) > p_).toType(x.type().scalarType()).mul_(1. / (1 - p_));
+    noise = (noise.uniform_(0, 1) > p_)
+                .toType(x.type().scalarType())
+                .mul_(1. / (1 - p_));
     lst.push_back(x * Var(noise));
   }
   return lst;

--- a/src/containers.cpp
+++ b/src/containers.cpp
@@ -4,9 +4,9 @@ namespace autograd {
 std::map<std::string, Variable> ContainerImpl::parameters() const {
   std::map<std::string, Variable> ret;
   for (auto pair : children_) {
-    auto &name = pair.first;
-    auto &child = pair.second;
-    for (auto &p : child->parameters()) {
+    auto& name = pair.first;
+    auto& child = pair.second;
+    for (auto& p : child->parameters()) {
       ret[name + "." + p.first] = p.second;
     }
   }
@@ -44,7 +44,7 @@ Variable &ContainerImpl::param(std::string const &name) {
 }
 
 void ContainerImpl::cuda() {
-  for (auto &pair : children_) {
+  for (auto& pair : children_) {
     pair.second->cuda();
   }
   cuda_ = true;
@@ -57,7 +57,7 @@ void ContainerImpl::cuda() {
 };
 
 void ContainerImpl::cpu() {
-  for (auto &pair : children_) {
+  for (auto& pair : children_) {
     pair.second->cpu();
   }
   cuda_ = false;
@@ -70,20 +70,20 @@ void ContainerImpl::cpu() {
 };
 
 void ContainerImpl::train() {
-  for (auto &pair : children_) {
+  for (auto& pair : children_) {
     pair.second->train();
   }
   train_ = true;
 }
 
 void ContainerImpl::eval() {
-  for (auto &pair : children_) {
+  for (auto& pair : children_) {
     pair.second->eval();
   }
   train_ = false;
 }
 
-Container ContainerImpl::add(Container m, std::string const &name) {
+Container ContainerImpl::add(Container m, std::string const& name) {
   if (this->children_.find(name) != this->children_.end()) {
     throw std::runtime_error("Trying to add container that already exists");
   }
@@ -96,7 +96,7 @@ Container ContainerImpl::add(Container m, std::string const &name) {
   return this->children_[name];
 }
 
-Variable &ContainerImpl::add(Variable v, std::string const &name) {
+Variable& ContainerImpl::add(Variable v, std::string const& name) {
   if (this->params_.find(name) != this->params_.end()) {
     throw std::runtime_error("Trying to add parameter that already exists");
   }
@@ -109,11 +109,9 @@ Variable &ContainerImpl::add(Variable v, std::string const &name) {
   return this->params_[name];
 }
 
-at::Type &ContainerImpl::DefaultTensor(at::ScalarType s) {
-  if (cuda_)
-    return at::CUDA(s);
-  else
-    return at::CPU(s);
+at::Type& ContainerImpl::DefaultTensor(at::ScalarType s) {
+  if (cuda_) return at::CUDA(s);
+  else return at::CPU(s);
 }
 
 variable_list Linear::forward(variable_list input) {
@@ -133,17 +131,15 @@ variable_list Linear::forward(variable_list input) {
 
 void Linear::reset_parameters() {
   auto stdv = 1.0 / std::sqrt(weight.size(1));
-  for (auto &p : parameters()) {
+  for (auto& p : parameters()) {
     p.second.data().uniform_(-stdv, stdv);
   }
 }
 
 void Linear::initialize_parameters() {
-  weight = this->add(Var(DefaultTensor(at::kFloat).tensor({nout, nin}), true),
-                     "weight");
+  weight = this->add(Var(DefaultTensor(at::kFloat).tensor({nout, nin}), true), "weight");
   if (!no_bias_) {
-    bias =
-        this->add(Var(DefaultTensor(at::kFloat).tensor({nout}), true), "bias");
+    bias = this->add(Var(DefaultTensor(at::kFloat).tensor({nout}), true), "bias");
   }
 }
 
@@ -153,24 +149,20 @@ variable_list Embedding::forward(variable_list input) {
 }
 
 void Embedding::reset_parameters() {
-  for (auto &p : parameters()) {
+  for (auto& p : parameters()) {
     p.second.data().normal_(0, 1);
   }
 }
 
 void Embedding::initialize_parameters() {
-  weight = this->add(
-      Var(DefaultTensor(at::kFloat).tensor({num_embeddings, embedding_dim}),
-          true),
-      "weight");
+  weight = this->add(Var(DefaultTensor(at::kFloat).tensor({num_embeddings, embedding_dim}), true), "weight");
 }
 
 void Conv::initialize_parameters() {
   if (!transposed_) {
     for (auto pad : output_padding_) {
       if (pad != 0) {
-        throw std::runtime_error(
-            "Only transposed convolutions support output padding!");
+        throw std::runtime_error("Only transposed convolutions support output padding!");
       }
     }
   }
@@ -184,11 +176,9 @@ void Conv::initialize_parameters() {
     wsize.push_back(in_channels_ / groups_);
   }
   wsize.insert(wsize.end(), ks_.begin(), ks_.end());
-  weight =
-      this->add(Var(DefaultTensor(at::kFloat).tensor(wsize), true), "weight");
+  weight = this->add(Var(DefaultTensor(at::kFloat).tensor(wsize), true), "weight");
   if (!no_bias_) {
-    bias = this->add(
-        Var(DefaultTensor(at::kFloat).tensor({out_channels_}), true), "bias");
+    bias = this->add(Var(DefaultTensor(at::kFloat).tensor({out_channels_}), true), "bias");
   } else {
     assert(!bias.defined());
   }
@@ -196,10 +186,9 @@ void Conv::initialize_parameters() {
 
 void Conv::reset_parameters() {
   auto n = in_channels_;
-  for (auto k : ks_)
-    n *= k;
+  for (auto k : ks_) n *= k;
   auto stdv = 1.0 / std::sqrt(n);
-  for (auto &p : parameters()) {
+  for (auto& p : parameters()) {
     p.second.data().uniform_(-stdv, stdv);
   }
 }
@@ -208,7 +197,7 @@ variable_list Conv::forward(variable_list input) {
   auto x = input[0];
   if (Nd_ == 1) {
     assert(x.ndimension() == 3);
-    x = x.unsqueeze(-1); // TODO: Use conv1d once available
+    x = x.unsqueeze(-1);  // TODO: Use conv1d once available
   } else if (Nd_ == 2) {
     assert(x.ndimension() == 4);
   } else if (Nd_ == 3) {
@@ -220,15 +209,13 @@ variable_list Conv::forward(variable_list input) {
   Variable out;
   if (Nd_ == 1 || Nd_ == 2) {
     if (transposed_) {
-      out = at::conv_transpose2d(x, weight, bias, stride_, padding_,
-                                 output_padding_, 1, dilation_);
+      out = at::conv_transpose2d(x, weight, bias, stride_, padding_, output_padding_, 1, dilation_);
     } else {
       out = at::conv2d(x, weight, bias, stride_, padding_, dilation_);
     }
   } else if (Nd_ == 3) {
     if (transposed_) {
-      out = at::conv_transpose3d(x, weight, bias, stride_, padding_,
-                                 output_padding_, 1, dilation_);
+      out = at::conv_transpose3d(x, weight, bias, stride_, padding_, output_padding_, 1, dilation_);
     } else {
       out = at::conv3d(x, weight, bias, stride_, padding_, dilation_);
     }
@@ -239,10 +226,8 @@ variable_list Conv::forward(variable_list input) {
 
 void BatchNorm::initialize_parameters() {
   if (affine_) {
-    weight = this->add(
-        Var(DefaultTensor(at::kFloat).tensor(num_features_), true), "weight");
-    bias = this->add(Var(DefaultTensor(at::kFloat).tensor(num_features_), true),
-                     "bias");
+    weight = this->add(Var(DefaultTensor(at::kFloat).tensor(num_features_), true), "weight");
+    bias = this->add(Var(DefaultTensor(at::kFloat).tensor(num_features_), true), "bias");
   }
 
   if (stateful_) {
@@ -264,9 +249,9 @@ void BatchNorm::reset_parameters() {
 }
 
 variable_list BatchNorm::forward(variable_list inputs) {
-  auto &input = inputs[0];
-  auto &running_mean = (stateful_ ? this->running_mean : inputs[1]);
-  auto &running_var = (stateful_ ? this->running_var : inputs[2]);
+  auto& input = inputs[0];
+  auto& running_mean = (stateful_ ? this->running_mean : inputs[1]);
+  auto& running_var = (stateful_ ? this->running_var : inputs[2]);
 
   if (train_) {
     const auto num_channels = input.dim() > 1 ? input.size(1) : 1;
@@ -276,13 +261,18 @@ variable_list BatchNorm::forward(variable_list inputs) {
     }
   }
 
-  auto output = at::batch_norm(input, weight, bias, running_mean, running_var,
-                               train_, momentum_, eps_, hasCudnn());
+  auto output = at::batch_norm(
+      input,
+      weight, bias,
+      running_mean, running_var,
+      train_, momentum_, eps_,
+      hasCudnn());
 
   return variable_list({output});
 }
 
-template <typename Derived> void RNNBase<Derived>::initialize_containers() {
+template <typename Derived>
+void RNNBase<Derived>::initialize_containers() {
   auto gate_size = hidden_size_;
   if (mode_ == RNNMode::LSTM) {
     gate_size *= 4;
@@ -292,26 +282,17 @@ template <typename Derived> void RNNBase<Derived>::initialize_containers() {
 
   for (auto i = 0U; i < nlayers_; i++) {
     auto input_size = (i == 0) ? input_size_ : hidden_size_;
-    // We get parameters names of the form [ih]h_l<layer num>.{weight}|{bias}
-    // whereas pytorch has {weight}|{bias}_[ih]h_l<layer num>
-    // Having the right parameter names would require to change the architecture
-    // and honestly the pytorch names are not really logical (their order is the
-    // inverse of the inclusion ordering)
-    i2h.push_back(
-        this->add(Linear(input_size, gate_size).no_bias(no_bias_).make(),
-                  "ih_l" + std::to_string(i)));
-    h2h.push_back(
-        this->add(Linear(hidden_size_, gate_size).no_bias(no_bias_).make(),
-                  "hh_l" + std::to_string(i)));
+    i2h.push_back(this->add(Linear(input_size, gate_size).no_bias(no_bias_).make(), "i2h_" + std::to_string(i)));
+    h2h.push_back(this->add(Linear(hidden_size_, gate_size).no_bias(no_bias_).make(), "h2h_" + std::to_string(i)));
   }
-  if (dropout_ > 0)
-    dropout_module = Dropout(dropout_).make();
+  if (dropout_ > 0) dropout_module = Dropout(dropout_).make();
   this->flatten_parameters();
 }
 
-template <typename Derived> void RNNBase<Derived>::reset_parameters() {
+template <typename Derived>
+void RNNBase<Derived>::reset_parameters() {
   auto stdv = 1.0 / std::sqrt(hidden_size_);
-  for (auto &p : this->parameters()) {
+  for (auto& p : this->parameters()) {
     p.second.data().uniform_(-stdv, stdv);
   }
 }
@@ -319,9 +300,9 @@ template <typename Derived> void RNNBase<Derived>::reset_parameters() {
 template <typename Derived>
 variable_list RNNBase<Derived>::GRU_cell_forward(variable_list inputs, int i) {
   auto x = inputs[0];
-  auto hx = inputs[1].defined() ? inputs[1]
-                                : Var(this->DefaultTensor(at::kFloat)
-                                          .zeros({x.size(0), hidden_size_}));
+  auto hx = inputs[1].defined()
+    ? inputs[1]
+    : Var(this->DefaultTensor(at::kFloat).zeros({x.size(0), hidden_size_}));
 
   auto gi = i2h[i]->forward({x})[0];
   auto gh = h2h[i]->forward({hx})[0];
@@ -337,24 +318,22 @@ variable_list RNNBase<Derived>::GRU_cell_forward(variable_list inputs, int i) {
 }
 
 template <typename Derived>
-variable_list RNNBase<Derived>::RNN_TANH_cell_forward(variable_list inputs,
-                                                      int i) {
+variable_list RNNBase<Derived>::RNN_TANH_cell_forward(variable_list inputs, int i) {
   auto x = inputs[0];
-  auto hx = inputs[1].defined() ? inputs[1]
-                                : Var(this->DefaultTensor(at::kFloat)
-                                          .zeros({x.size(0), hidden_size_}));
+  auto hx = inputs[1].defined()
+    ? inputs[1]
+    : Var(this->DefaultTensor(at::kFloat).zeros({x.size(0), hidden_size_}));
 
   auto h = (i2h[i]->forward({x})[0] + h2h[i]->forward({hx})[0]).tanh();
   return variable_list({h});
 }
 
 template <typename Derived>
-variable_list RNNBase<Derived>::RNN_RELU_cell_forward(variable_list inputs,
-                                                      int i) {
+variable_list RNNBase<Derived>::RNN_RELU_cell_forward(variable_list inputs, int i) {
   auto x = inputs[0];
-  auto hx = inputs[1].defined() ? inputs[1]
-                                : Var(this->DefaultTensor(at::kFloat)
-                                          .zeros({x.size(0), hidden_size_}));
+  auto hx = inputs[1].defined()
+    ? inputs[1]
+    : Var(this->DefaultTensor(at::kFloat).zeros({x.size(0), hidden_size_}));
 
   auto h = (i2h[i]->forward({x})[0] + h2h[i]->forward({hx})[0]).clamp_min(0);
   return variable_list({h});
@@ -364,9 +343,8 @@ template <typename Derived>
 variable_list RNNBase<Derived>::LSTM_cell_forward(variable_list inputs, int i) {
   auto x = inputs[0];
   auto hid = inputs[1].defined()
-                 ? inputs[1]
-                 : Var(this->DefaultTensor(at::kFloat)
-                           .zeros({2, x.size(0), hidden_size_}));
+    ? inputs[1]
+    : Var(this->DefaultTensor(at::kFloat).zeros({2, x.size(0), hidden_size_}));
   auto hx = hid[0];
   auto cx = hid[1];
 
@@ -386,16 +364,11 @@ variable_list RNNBase<Derived>::LSTM_cell_forward(variable_list inputs, int i) {
 
 template <typename Derived>
 variable_list RNNBase<Derived>::cell_forward(variable_list inputs, int i) {
-  if (mode_ == RNNMode::LSTM)
-    return LSTM_cell_forward(inputs, i);
-  else if (mode_ == RNNMode::GRU)
-    return GRU_cell_forward(inputs, i);
-  else if (mode_ == RNNMode::RNN_TANH)
-    return RNN_TANH_cell_forward(inputs, i);
-  else if (mode_ == RNNMode::RNN_RELU)
-    return RNN_RELU_cell_forward(inputs, i);
-  else
-    throw std::runtime_error("No such RNN mode");
+  if (mode_ == RNNMode::LSTM) return LSTM_cell_forward(inputs, i);
+  else if (mode_ == RNNMode::GRU) return GRU_cell_forward(inputs, i);
+  else if (mode_ == RNNMode::RNN_TANH) return RNN_TANH_cell_forward(inputs, i);
+  else if (mode_ == RNNMode::RNN_RELU) return RNN_RELU_cell_forward(inputs, i);
+  else throw std::runtime_error("No such RNN mode");
 }
 
 template <typename Derived>
@@ -404,13 +377,13 @@ variable_list RNNBase<Derived>::autograd_forward(variable_list inputs) {
 
   std::vector<Tensor> hidden;
   for (size_t i = 0; i < nlayers_; i++) {
-    hidden.push_back(inputs[1].defined() ? inputs[1][i] : tag::Variable());
+    hidden.push_back(inputs[1].defined()
+        ? inputs[1][i]
+        : tag::Variable());
   }
 
-  auto output = Var(this->DefaultTensor(at::kFloat)
-                        .zeros({inp.size(0), inp.size(1), hidden_size_}),
-                    false);
-  for (auto t = 0U; t < inp.size(0); t++) {
+  auto output = Var(this->DefaultTensor(at::kFloat).zeros({inp.size(0), inp.size(1), hidden_size_}), false);
+  for (auto t = 0U; t < inp.size(0); t++ ) {
     auto x = inp.select(0, t);
     for (size_t i = 0; i < nlayers_; i++) {
       auto layer_output = cell_forward({x, hidden[i]}, i);
@@ -432,22 +405,21 @@ variable_list RNNBase<Derived>::autograd_forward(variable_list inputs) {
   return variable_list({output, hidout});
 }
 
-template <typename Derived> bool RNNBase<Derived>::flatten_parameters() {
+template <typename Derived>
+bool RNNBase<Derived>::flatten_parameters() {
   data_ptrs_.clear();
   auto anyParam = i2h[0]->params_.begin()->second;
   if (!anyParam.is_cuda() || !at::cudnn_is_acceptable(anyParam)) {
     return false;
   }
-  std::unordered_set<void *> unique_data_ptrs;
+  std::unordered_set<void*> unique_data_ptrs;
   auto params = this->parameters();
-  for (auto &p : params) {
+  for (auto& p : params) {
     unique_data_ptrs.insert(p.second.data().data_ptr());
   }
   // TODO PyTorch says:
-  // If any parameters alias, we fall back to the slower, copying code path.
-  // This is
-  // a sufficient check, because overlapping parameter buffers that don't
-  // completely
+  // If any parameters alias, we fall back to the slower, copying code path. This is
+  // a sufficient check, because overlapping parameter buffers that don't completely
   // alias would break the assumptions of the uniqueness check in
   // Module.named_parameters().
   // But I'm not sure if this is the case for us
@@ -469,11 +441,16 @@ template <typename Derived> bool RNNBase<Derived>::flatten_parameters() {
   {
     no_grad_guard guard;
     flat_weight_ = at::_cudnn_rnn_flatten_weight(
-        weight_list, weight_stride0, input_size_, mode_, hidden_size_, nlayers_,
-        false,
-        false); // batch_first and bidirectional, unsupported
+      weight_list,
+      weight_stride0,
+      input_size_,
+      mode_,
+      hidden_size_,
+      nlayers_,
+      false,
+      false); // batch_first and bidirectional, unsupported
   }
-  for (auto &p : params) {
+  for (auto& p : params) {
     data_ptrs_.emplace_back(p.second.data().data_ptr());
   }
   return true;
@@ -505,34 +482,40 @@ variable_list RNNBase<Derived>::CUDNN_forward(variable_list inputs) {
   }
   auto dropout_state = x.type().tensor();
 
-  std::vector<void *> weight_data_ptrs;
+  std::vector<void*> weight_data_ptrs;
   auto params = this->parameters();
-  for (auto &p : params) {
+  for (auto& p : params) {
     weight_data_ptrs.emplace_back(p.second.data().data_ptr());
   }
   if (weight_data_ptrs != data_ptrs_) {
     std::cerr << "Parameters are unflattened! Code path might be super slow. "
-                 "Please call flatten_parameters() when you muck around with "
-                 "storages!"
-              << std::endl;
+      "Please call flatten_parameters() when you muck around with storages!"
+      << std::endl;
     flat_weight_ = Variable();
   }
 
   // tup = std::tuple of output, hy, cy, reserve, new_weight_buf
   auto tup = _cudnn_rnn(
-      x, weight_list, weight_stride0, flat_weight_, hx, cx, mode_, hidden_size_,
+      x,
+      weight_list,
+      weight_stride0,
+      flat_weight_,
+      hx,
+      cx,
+      mode_,
+      hidden_size_,
       nlayers_,
       false, // batch first
-      0,     // TODO waiting on dropout state descriptor in C++ pytorch
+      0, // TODO waiting on dropout state descriptor in C++ pytorch
       this->train_,
-      false,        // bidirectional
-      {},           // packing not supported
+      false, // bidirectional
+      {}, // packing not supported
       dropout_state // TODO waiting on dropout state descriptor in C++ pytorch
       );
 
   Variable hidout = mode_ == RNNMode::LSTM
-                        ? at::stack({std::get<1>(tup), std::get<2>(tup)}, 0)
-                        : std::get<1>(tup);
+    ? at::stack({std::get<1>(tup), std::get<2>(tup)}, 0)
+    : std::get<1>(tup);
   Variable output = std::get<0>(tup);
   return variable_list({output, hidout});
 }
@@ -549,45 +532,41 @@ variable_list RNNBase<Derived>::forward(variable_list inputs) {
 
   // Dropout descriptors aren't in C++ in PyTorch yet...
   auto output = at::cudnn_is_acceptable(inp[0]) && dropout_ == 0
-                    ? CUDNN_forward(inp)
-                    : autograd_forward(inp);
+    ? CUDNN_forward(inp)
+    : autograd_forward(inp);
 
   return output;
 }
 
-template <typename Derived> void RNNBase<Derived>::cuda() {
+template <typename Derived>
+void RNNBase<Derived>::cuda() {
   Container_CRTP<Derived>::cuda();
   flatten_parameters();
 }
 
-template <typename Derived> void RNNBase<Derived>::cpu() {
+template <typename Derived>
+void RNNBase<Derived>::cpu() {
   Container_CRTP<Derived>::cpu();
   flatten_parameters();
 }
 
 variable_list Dropout::forward(variable_list inputs) {
-  if (p_ == 0 || !this->train_)
-    return inputs;
+  if (p_ == 0 || !this->train_) return inputs;
   variable_list lst;
   for (auto x : inputs) {
     auto noise = x.data().type().tensor(x.sizes());
-    noise = (noise.uniform_(0, 1) > p_)
-                .toType(x.type().scalarType())
-                .mul_(1. / (1 - p_));
+    noise = (noise.uniform_(0, 1) > p_).toType(x.type().scalarType()).mul_(1. / (1 - p_));
     lst.push_back(x * Var(noise));
   }
   return lst;
 }
 
 variable_list Dropout2d::forward(variable_list inputs) {
-  if (p_ == 0 || !this->train_)
-    return inputs;
+  if (p_ == 0 || !this->train_) return inputs;
   variable_list lst;
   for (auto x : inputs) {
     auto noise = x.data().type().tensor({x.size(0), x.size(1), 1, 1});
-    noise = (noise.uniform_(0, 1) > p_)
-                .toType(x.type().scalarType())
-                .mul_(1. / (1 - p_));
+    noise = (noise.uniform_(0, 1) > p_).toType(x.type().scalarType()).mul_(1. / (1 - p_));
     lst.push_back(x * Var(noise));
   }
   return lst;


### PR DESCRIPTION
## List of changes:
- uses '.' instead of '/' as a name delimiter in the container tree (to mimic pytorch)
- tentative changes to rnn parameters names to resemble more pytorch's,
- Functional container designed for use in Sequential,
- ~clang-format~.