### PR TITLE
Fix serialization of contiguous tensor views

### DIFF
--- a/include/autogradpp/serialization.h
+++ b/include/autogradpp/serialization.h
@@ -111,11 +111,15 @@ void save(Archive& archive, at::Tensor const& tensor) {
     sizes.push_back(s);
   }
   auto contig = tensor.toBackend(at::kCPU).contiguous();
-  uint64_t size = tensor.storage()->size() * tensor.storage()->elementSize();
+  uint64_t size = tensor.numel() * tensor.storage()->elementSize();
   at::Backend backend = tensor.type().backend();
 
   archive(CEREAL_NVP(backend), CEREAL_NVP(sizes), CEREAL_NVP(size));
-  agimpl::saveBinary(archive, contig.storage()->data(), size);
+  agimpl::saveBinary(
+      archive,
+      static_cast<char*>(contig.storage()->data()) +
+          contig.storage_offset() * contig.storage()->elementSize(),
+      size);
 }
 
 /**
@@ -142,14 +146,19 @@ void load(Archive& archive, at::Tensor& tensor) {
   if (!tensor.defined() || tensor.type().scalarType() != type) {
     tensor = at::getType(backend, type).tensor();
   }
+  tensor.resize_(sizes);
+
+  // Backward compatibility with older code that used to save "size" as the
+  // total size of the underlying storage
+  size = std::min(
+      size, tensor.storage()->size() * tensor.storage()->elementSize());
+
   if (tensor.type().is_cuda()) {
     // should actually use cudamemcpy probably
     auto cputensor = at::CPU(tensor.type().scalarType()).tensor(sizes);
-    tensor.resize_(sizes);
     agimpl::loadBinary(archive, cputensor.storage()->data(), size);
     tensor.copy_(cputensor);
   } else {
-    tensor.resize_(sizes);
     agimpl::loadBinary(archive, tensor.storage()->data(), size);
   }
 }

--- a/tests/serialization_t.cpp
+++ b/tests/serialization_t.cpp
@@ -54,6 +54,66 @@ CASE("serialization/portable_binary") {
   EXPECT(x.allclose(y));
 }
 
+CASE("serialization/resized") {
+  auto x = at::CPU(at::kFloat).randn({11, 5});
+  x.resize_({5, 5});
+  auto y = at::Tensor();
+
+  std::stringstream ss;
+  {
+    cereal::BinaryOutputArchive archive(ss);
+    archive(x);
+  }
+  {
+    cereal::BinaryInputArchive archive(ss);
+    archive(y);
+  }
+
+  EXPECT(y.defined());
+  EXPECT(x.sizes().vec() == y.sizes().vec());
+  EXPECT(x.allclose(y));
+}
+
+CASE("serialization/sliced") {
+  auto x = at::CPU(at::kFloat).randn({11, 5});
+  x = x.slice(0, 1, 3);
+  auto y = at::Tensor();
+
+  std::stringstream ss;
+  {
+    cereal::BinaryOutputArchive archive(ss);
+    archive(x);
+  }
+  {
+    cereal::BinaryInputArchive archive(ss);
+    archive(y);
+  }
+
+  EXPECT(y.defined());
+  EXPECT(x.sizes().vec() == y.sizes().vec());
+  EXPECT(x.allclose(y));
+}
+
+CASE("serialization/noncontig") {
+  auto x = at::CPU(at::kFloat).randn({11, 5});
+  x = x.slice(1, 1, 4);
+  auto y = at::Tensor();
+
+  std::stringstream ss;
+  {
+    cereal::BinaryOutputArchive archive(ss);
+    archive(x);
+  }
+  {
+    cereal::BinaryInputArchive archive(ss);
+    archive(y);
+  }
+
+  EXPECT(y.defined());
+  EXPECT(x.sizes().vec() == y.sizes().vec());
+  EXPECT(x.allclose(y));
+}
+
 CASE("serialization/xor") {
   // We better be able to save and load a XOR model!
   auto makeModel = []() {


### PR DESCRIPTION
Two of the new test cases, `serialization/resized` and `serialization/sliced`
would previously result in out-of-bound writes or simply wrong data. This is
fixed by writing the correct portion of the underlying storage. Tensors that
have been serialized with older coder can still be loaded.

Another test, `serialization/noncontig`, has been added for the sake of
completeness.